### PR TITLE
Migrate organizers from use profile to use user

### DIFF
--- a/app/assets/javascripts/app/helpers/user_select.js
+++ b/app/assets/javascripts/app/helpers/user_select.js
@@ -1,0 +1,29 @@
+Skyderby.helpers.UserSelect = function(elem, opts) {
+
+    if (!opts) opts = {};
+
+    var options = {
+        theme: 'bootstrap',
+        containerCssClass: ':all:',
+        width: '100%',
+        allowClear: true,
+        ajax: {
+            url: '/users/select_options',
+            dataType: 'json',
+            type: "GET",
+            quietMillis: 50,
+            data: function (params) {
+                return {
+                  query: params.term,
+                  page: params.page
+                };
+            },
+            cache: true
+        }
+    };
+
+    $.extend(options, opts);
+
+    Skyderby.helpers.select2_fix_open_on_clear(elem);
+    elem.select2(options);
+};

--- a/app/controllers/organizers_controller.rb
+++ b/app/controllers/organizers_controller.rb
@@ -42,7 +42,7 @@ class OrganizersController < ApplicationController
   end
 
   def organizer_params
-    params.require(:organizer).permit(:profile_id)
+    params.require(:organizer).permit(:user_id)
   end
 
   def organizable

--- a/app/controllers/profiles/select_options_controller.rb
+++ b/app/controllers/profiles/select_options_controller.rb
@@ -1,20 +1,13 @@
 module Profiles
   class SelectOptionsController < ApplicationController
     def index
-      @profiles = Profile.order(:name)
-
-      @profiles = @profiles.owned_by_users if only_registered?
-      @profiles = @profiles.search(search_query) if search_query
+      @profiles = Profile.search(search_query).order(:name)
     end
 
     private
 
     def search_query
-      params[:query] && params[:query][:term]
-    end
-
-    def only_registered?
-      params[:query] && params[:query][:only_registered]
+      params.dig(:query, :term)
     end
   end
 end

--- a/app/controllers/users/select_options_controller.rb
+++ b/app/controllers/users/select_options_controller.rb
@@ -1,0 +1,22 @@
+module Users
+  class SelectOptionsController < ApplicationController
+    def index
+      @users = User.includes(:profile)
+                   .left_outer_joins(:profile)
+                   .search_by_name(search_query)
+                   .select('users.id', 'profiles.name')
+                   .order('profiles.name')
+                   .paginate(page: page, per_page: 25)
+    end
+
+    private
+
+    def search_query
+      params.dig(:query, :term)
+    end
+
+    def page
+      params.dig(:query, :page)
+    end
+  end
+end

--- a/app/models/concerns/participant_of_events.rb
+++ b/app/models/concerns/participant_of_events.rb
@@ -1,0 +1,37 @@
+# Concern used by User model and provides interface that used in policies
+# to check permissions to view and change event or tournament
+module ParticipantOfEvents
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :responsible_of_events,
+             class_name: 'Event',
+             foreign_key: 'responsible_id',
+             dependent: :nullify,
+             inverse_of: :responsible
+
+    has_many :responsible_of_tournaments,
+             class_name: 'Tournament',
+             foreign_key: 'responsible_id',
+             dependent: :nullify,
+             inverse_of: :responsible
+
+    has_many :organizers, dependent: :restrict_with_error
+  end
+
+  def organizer_of_events
+    organizers.select(:organizable_id, :organizable_type).map(&:organizable)
+  end
+
+  def organizer_of_event?(event)
+    (responsible_of_events + responsible_of_tournaments + organizer_of_events).include? event
+  end
+
+  def participant_of_events
+    organizer_of_events + competitor_of_events
+  end
+
+  def competitor_of_events
+    profile&.competitor_of_events || []
+  end
+end

--- a/app/models/guest_user.rb
+++ b/app/models/guest_user.rb
@@ -43,6 +43,10 @@ class GuestUser
     []
   end
 
+  def organizer_of_event?(_event)
+    false
+  end
+
   def responsible_of_events
     []
   end

--- a/app/models/organizer.rb
+++ b/app/models/organizer.rb
@@ -14,11 +14,11 @@ class Organizer < ApplicationRecord
   include EventOngoingValidation
 
   belongs_to :organizable, polymorphic: true
-  belongs_to :profile
+  belongs_to :user
 
-  validates :organizable, :profile, presence: true
+  validates :organizable, :user, presence: true
 
-  delegate :name, to: :profile, allow_nil: true
+  delegate :name, to: :user, allow_nil: true
 
   alias event organizable
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -33,14 +33,8 @@ class Profile < ApplicationRecord
            class_name: 'Track'
   has_many :base_tracks, -> { base.order('created_at DESC') }, class_name: 'Track'
   has_many :badges, -> { order(achieved_at: :desc) }, dependent: :delete_all
-  has_many :events, dependent: :restrict_with_error
-  has_many :organizers, dependent: :restrict_with_error
   has_many :competitors, dependent: :restrict_with_error
   has_many :personal_top_scores
-
-  scope :owned_by_users, -> do
-    joins("INNER JOIN users ON owner_id = users.id AND owner_type = 'User'")
-  end
 
   has_attached_file :userpic,
                     styles: { large: '500x500>',
@@ -65,20 +59,12 @@ class Profile < ApplicationRecord
     super.presence || 'Name not set'
   end
 
-  def organizer_of_events
-    organizers.select(:organizable_id, :organizable_type).map(&:organizable)
-  end
-
   def competitor_of_events
     competitors.select(:event_id).map(&:event)
   end
 
   def participant_of_events
     organizer_of_events + competitor_of_events
-  end
-
-  def responsible_of_events
-    events
   end
 
   class << self

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -61,15 +61,5 @@ class ApplicationPolicy
     def admin?
       user&.has_role? :admin
     end
-
-    def profile
-      user&.profile || NullProfile.new
-    end
-
-    class NullProfile
-      def participant_of_events
-        []
-      end
-    end
   end
 end

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -34,7 +34,7 @@ class EventPolicy < ApplicationPolicy
   def organizer?
     return false unless user.registered?
 
-    responsible? || user.organizer_of_events.include?(record)
+    responsible? || user.organizer_of_event?(record)
   end
 
   def responsible?

--- a/app/policies/profile_policy.rb
+++ b/app/policies/profile_policy.rb
@@ -21,6 +21,6 @@ class ProfilePolicy < ApplicationPolicy
   end
 
   def organizer_of_event?
-    (user.responsible_of_events + user.organizer_of_events).include?(record.owner)
+    user.organizer_of_event?(record.owner)
   end
 end

--- a/app/views/organizers/_form_modal.html.haml
+++ b/app/views/organizers/_form_modal.html.haml
@@ -16,10 +16,10 @@
 
       .modal-body
         .form-group
-          = f.label :profile, class: 'control-label col-sm-4'
+          = f.label :user, class: 'control-label col-sm-4'
           .col-sm-8
-            = f.select :profile_id,
-                       options_for_select([[organizer.name, organizer.profile_id]]),
+            = f.select :user_id,
+                       options_for_select([[organizer.name, organizer.user_id]]),
                        {},
                        class: 'form-control'
 

--- a/app/views/organizers/new.js.erb
+++ b/app/views/organizers/new.js.erb
@@ -1,10 +1,9 @@
 $('#modal').html("<%= j render('form_modal', organizer: @organizer) %>");
 $('#modal').modal('show');
 
-Skyderby.helpers.ProfileSelect(
-  $('select[name="organizer[profile_id]"]'),
+Skyderby.helpers.UserSelect(
+  $('select[name="organizer[user_id]"]'),
   {
-    only_registered: true,
     placeholder: "<%= t('organizers.form.profile_placeholder') %>"
   }
 );

--- a/app/views/users/select_options/index.json.jbuilder
+++ b/app/views/users/select_options/index.json.jbuilder
@@ -1,0 +1,8 @@
+json.results @users do |user|
+  json.id user.id
+  json.text user.name
+end
+
+json.pagination do |json|
+  json.more @users.next_page ? true : false
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,7 +93,13 @@ Skyderby::Application.routes.draw do
   devise_for :users
   resources :users do
     resource :masquerades, only: [:new, :destroy]
+    scope module: :users do
+      collection do
+        resources :select_options, only: :index
+      end
+    end
   end
+
   resources :profiles do
     scope module: :profiles do
       resources :badges, only: [:new, :create]

--- a/db/migrate/20180227134232_change_organizers_from_profile_to_users.rb
+++ b/db/migrate/20180227134232_change_organizers_from_profile_to_users.rb
@@ -1,0 +1,29 @@
+class ChangeOrganizersFromProfileToUsers < ActiveRecord::Migration[5.1]
+  def up
+    add_reference :organizers, :user, index: true
+
+    execute(<<~SQL)
+      UPDATE organizers
+      SET user_id = profiles.owner_id
+      FROM profiles
+      WHERE organizers.profile_id = profiles.id
+      AND profiles.owner_type = 'User'
+    SQL
+
+    remove_reference :organizers, :profile
+  end
+
+  def down
+    add_reference :organizers, :profile
+
+    execute(<<~SQL)
+      UPDATE organizers
+      SET profile_id = profiles.id
+      FROM profiles
+      WHERE organizers.user_id = profiles.owner_id
+      AND profiles.owner_type = 'User'
+    SQL
+
+    remove_reference :organizers, :user
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180226070838) do
+ActiveRecord::Schema.define(version: 20180227134232) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -96,12 +96,12 @@ ActiveRecord::Schema.define(version: 20180226070838) do
 
   create_table "organizers", id: :serial, force: :cascade do |t|
     t.integer "organizable_id"
-    t.integer "profile_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "organizable_type"
+    t.bigint "user_id"
     t.index ["organizable_id"], name: "index_organizers_on_organizable_id"
-    t.index ["profile_id"], name: "index_organizers_on_profile_id"
+    t.index ["user_id"], name: "index_organizers_on_user_id"
   end
 
   create_table "place_lines", force: :cascade do |t|
@@ -437,7 +437,6 @@ ActiveRecord::Schema.define(version: 20180226070838) do
   add_foreign_key "competitors", "profiles"
   add_foreign_key "event_tracks", "tracks"
   add_foreign_key "events", "profiles"
-  add_foreign_key "organizers", "profiles"
   add_foreign_key "profiles", "countries"
   add_foreign_key "qualification_jumps", "qualification_rounds"
   add_foreign_key "qualification_jumps", "tracks"
@@ -512,7 +511,7 @@ ActiveRecord::Schema.define(version: 20180226070838) do
               events_1.created_at
              FROM events events_1
           UNION ALL
-           SELECT 'Tournament'::text,
+           SELECT 'Tournament'::text AS text,
               tournaments.id,
               tournaments.starts_at,
               1,

--- a/spec/controllers/tracks_controller_spec.rb
+++ b/spec/controllers/tracks_controller_spec.rb
@@ -41,7 +41,7 @@ describe TracksController do
       organizer = create :user
 
       event = create :event, responsible: responsible
-      create :event_organizer, organizable: event, profile: organizer.profile
+      create :event_organizer, organizable: event, user: organizer
 
       track = create :empty_track, :with_point, owner: event
 

--- a/spec/factories/organizers.rb
+++ b/spec/factories/organizers.rb
@@ -12,12 +12,12 @@
 
 FactoryBot.define do
   factory :event_organizer, class: 'Organizer' do
-    profile
+    user
     association :organizable, factory: :event
   end
 
   factory :tournament_organizer, class: 'Organizer' do
-    profile
+    user
     association :organizable, factory: :tournament
   end
 end

--- a/spec/models/organizer_spec.rb
+++ b/spec/models/organizer_spec.rb
@@ -17,11 +17,11 @@ describe Organizer, type: :model do
   end
 
   it 'requires event' do
-    profile = create :profile
-    expect(Organizer.create(profile: profile)).not_to be_valid
+    user = create :user
+    expect(Organizer.create(user: user)).not_to be_valid
   end
 
-  it 'requires user profile' do
+  it 'requires user' do
     event = create :event
     expect(Organizer.create(organizable: event)).not_to be_valid
   end

--- a/spec/policies/event_list_policy_scope_spec.rb
+++ b/spec/policies/event_list_policy_scope_spec.rb
@@ -11,7 +11,7 @@ describe EventListPolicy::Scope do
     events = create_events
     user = create :user
 
-    create :event_organizer, profile: user.profile, organizable: events[:public_draft]
+    create :event_organizer, user: user, organizable: events[:public_draft]
 
     event_array = EventListPolicy::Scope.new(user, EventList.all).resolve.map(&:event)
     expect(event_array).to match_array [events[:public_draft], events[:public_finished]]

--- a/spec/policies/event_policy_spec.rb
+++ b/spec/policies/event_policy_spec.rb
@@ -116,7 +116,7 @@ describe EventPolicy do
     it 'allowed to organizer' do
       event = create(:event)
 
-      create :event_organizer, organizable: event, profile: user.profile
+      create :event_organizer, organizable: event, user: user
 
       expect(EventPolicy.new(user, event).update?).to be_truthy
     end
@@ -138,7 +138,7 @@ describe EventPolicy do
     it 'not allowed to organizer' do
       event = create(:event)
 
-      create :event_organizer, organizable: event, profile: user.profile
+      create :event_organizer, organizable: event, user: user
 
       expect(EventPolicy.new(user, event).destroy?).to be_falsey
     end

--- a/spec/policies/profile_policy_spec.rb
+++ b/spec/policies/profile_policy_spec.rb
@@ -34,7 +34,7 @@ describe ProfilePolicy do
     it 'allowed to organizer of event' do
       user = create :user
       event = create :event
-      organizer = create :event_organizer, organizable: event, profile: user.profile
+      organizer = create :event_organizer, organizable: event, user: user
 
       profile = create :profile, owner: event
       expect(ProfilePolicy.new(user, profile).update?).to be_truthy

--- a/spec/system/competitions/event_organizers_spec.rb
+++ b/spec/system/competitions/event_organizers_spec.rb
@@ -13,7 +13,7 @@ feature 'Event organizers', type: :system, js: true do
 
     click_link I18n.t('organizers.list.add_judge')
 
-    find('#select2-organizer_profile_id-container').click
+    find('#select2-organizer_user_id-container').click
     sleep 0.5
     first('li.select2-results__option', text: organizer.name).click
     sleep 0.5


### PR DESCRIPTION
This change mad in order to make code cleaner.
Previously was:
Profile belongs_to User
Organizer belongs_to Profile

When adding organizers to event filter on "profile has user" is applied
Policy check permission through user.profile

These changes make it simple:
Organizers belongs_to User

When adding organizer no filter applied
Policy check if user is responsible or organizer of event.