### PR TITLE
Introduce Open category for PPC competitions

### DIFF
--- a/app/controllers/concerns/event_scoped.rb
+++ b/app/controllers/concerns/event_scoped.rb
@@ -6,7 +6,7 @@ module EventScoped
   end
 
   def display_event_params
-    params.permit(:display_raw_results, :omit_penalties)
+    params.permit(:display_raw_results, :omit_penalties, :split_by_categories)
   end
 
   def respond_with_scoreboard

--- a/app/helpers/events/results_helper.rb
+++ b/app/helpers/events/results_helper.rb
@@ -19,7 +19,6 @@ module Events
               remote: !mobile?,
               class: 'show-result',
               rel: 'nofollow') do
-
         class_list = can_update ? 'fas fa-pencil-alt' : 'fa fa-search'
         content_tag('i', nil, class: class_list)
       end

--- a/app/presenters/events/scoreboards/params.rb
+++ b/app/presenters/events/scoreboards/params.rb
@@ -22,6 +22,10 @@ module Events
         !apply_penalty_to_score?
       end
 
+      def split_by_categories?
+        raw_params[:split_by_categories].to_s.downcase != 'false'
+      end
+
       private
 
       attr_reader :event, :raw_params

--- a/app/presenters/events/scoreboards/speed_distance_time.rb
+++ b/app/presenters/events/scoreboards/speed_distance_time.rb
@@ -5,7 +5,7 @@ module Events
 
       attr_reader :event
 
-      delegate :adjust_to_wind?, to: :params
+      delegate :adjust_to_wind?, :split_by_categories?, to: :params
       delegate :wind_cancellation, to: :event
 
       def initialize(event, params)
@@ -22,9 +22,14 @@ module Events
       end
 
       def sections
-        @sections ||= event.sections.order(:order).map do |section|
-          Category.new(section, self, CompetitorsCollection)
-        end
+        @sections ||=
+          if split_by_categories?
+            event.sections.order(:order).map do |section|
+              Category.new(section, self, CompetitorsCollection)
+            end
+          else
+            [OpenCategory.new(self, CompetitorsCollection)]
+          end
       end
 
       def rounds

--- a/app/presenters/events/scoreboards/speed_distance_time/open_category.rb
+++ b/app/presenters/events/scoreboards/speed_distance_time/open_category.rb
@@ -1,0 +1,25 @@
+module Events
+  module Scoreboards
+    class SpeedDistanceTime
+      class OpenCategory
+        def initialize(scoreboard, collection_class)
+          @scoreboard = scoreboard
+          @event = scoreboard.event
+          @collection_class = collection_class
+        end
+
+        def competitors
+          @competitors ||= collection_class.new \
+            event.competitors.includes(profile: [:country], suit: [:manufacturer]),
+            scoreboard
+        end
+
+        def id; end
+
+        private
+
+        attr_reader :event, :scoreboard, :collection_class
+      end
+    end
+  end
+end

--- a/app/views/events/sections/_section_row.html.haml
+++ b/app/views/events/sections/_section_row.html.haml
@@ -1,3 +1,6 @@
+-# Open category (when splitting by categories is disabled) doesn't have id
+- return unless section.id
+
 %tr{id: dom_id(section)}
   %td.event__scoreboard-section{colspan: columns_count}
     %span.section__name= section.name


### PR DESCRIPTION
The option is not in interface right now (before we verify the correctness of results).

To try it - simply add query param to URL `split_by_categories=false`