### PR TITLE
Fix highchart destoy glitch

### DIFF
--- a/app/javascript/components/Highchart/Series.js
+++ b/app/javascript/components/Highchart/Series.js
@@ -15,7 +15,7 @@ const Series = ({ chart, data, ...props }) => {
   }, [chart, data, props])
 
   useEffect(() => {
-    return () => series.current?.destroy()
+    return () => series.current?.chart && series.current?.destroy()
   }, [])
 
   return null

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "css-loader": "^2.1.1",
     "formik": "^2.0.1-rc.13",
     "geodesy": "^2.2.0",
-    "highcharts": "^6.0.7",
+    "highcharts": "^6.2.0",
     "honeybadger-js": "^0.5.5",
     "i18n-js": "^3.5.1",
     "immer": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4763,7 +4763,7 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-highcharts@^6.0.7:
+highcharts@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-6.2.0.tgz#2a6d04652eb43c66f462ca7e2d2808f1f2782b61"
   integrity sha512-A4E89MA+kto8giic7zyLU6ZxfXnVeCUlKOyzFsah3+n4BROx4bgonl92KIBtwLud/mIWir8ahqhuhe2by9LakQ==


### PR DESCRIPTION
We found that on unmouting components:
1. react unmount parent first
2. then unmount all childrens
For chart that means, series still alive while chart is destroed