### PR TITLE
Fix race condition on track save

### DIFF
--- a/app/services/create_track_service.rb
+++ b/app/services/create_track_service.rb
@@ -24,8 +24,9 @@ class CreateTrackService
       set_jump_range
       set_place
       save_track
-      enque_jobs
     end
+
+    enque_jobs
 
     track
   end


### PR DESCRIPTION
Together with @xird we found race condition on track save.
The problem is that jobs being enqueued from within a transaction and most probably is not picked up by jobs processor because track is not visible until transaction commited.
In this PR we moved jobs enqueue outside of transaction.