### PR TITLE
Fix invisible result text on iOS Safari dark mode

### DIFF
--- a/app/assets/stylesheets/_scoreboards.css
+++ b/app/assets/stylesheets/_scoreboards.css
@@ -167,6 +167,7 @@
 
 .scoreboard-table .result-show-cell button {
   background-color: var(--white);
+  color: var(--gray-90);
   text-align: right;
   border: 0;
   padding: 0.5rem;
@@ -188,6 +189,7 @@
 
 .scoreboard-table a.result-show-cell {
   background-color: var(--white);
+  color: var(--gray-90);
   text-align: right;
   border: 0;
   padding: 0.5rem;


### PR DESCRIPTION
## Summary
- Result values in the speed skydiving scoreboard rendered as invisible white text on a white background for users viewing the site on iOS Safari with system dark mode enabled.
- Root cause: `.scoreboard-table .result-show-cell button` (and the `a.result-show-cell` variant) explicitly set `background-color: var(--white)` but did not set `color`. Without an explicit color, iOS Safari falls back to the system `ButtonText` UA color, which becomes white-ish under dark mode.
- Fix: explicitly set `color: var(--gray-90)` on both rules so the text color no longer depends on system UA defaults.

## Test plan
- [ ] Open a speed skydiving competition scoreboard on iOS Safari with system dark mode enabled and confirm result values are readable.
- [ ] Verify desktop rendering is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)