### PR TITLE
Add Stripe-backed seat payments for competitions

### DIFF
--- a/app/assets/stylesheets/_event_payments.css
+++ b/app/assets/stylesheets/_event_payments.css
@@ -1,0 +1,88 @@
+.payments-status {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-top: 1rem;
+  border-left: 4px solid var(--green-500, #22c55e);
+}
+
+.payments-status--underpaid {
+  border-left-color: var(--red-500, #ef4444);
+}
+
+.payments-status__primary {
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.payments-status__secondary {
+  color: var(--red-500, #ef4444);
+  font-weight: 500;
+}
+
+.payments-buy {
+  margin-top: 1rem;
+}
+
+.payments-buy__title {
+  margin: 0 0 0.25rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.payments-buy__price {
+  color: var(--text-muted, #6b7280);
+  margin: 0 0 0.75rem;
+}
+
+.payments-buy__form {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.payments-buy__label {
+  font-weight: 500;
+}
+
+.payments-buy__input {
+  width: 5rem;
+  padding: 0.4rem 0.5rem;
+  border: 1px solid var(--border-color, #d1d5db);
+  border-radius: var(--border-radius-md, 4px);
+}
+
+.payments-buy__total {
+  font-weight: 600;
+  font-size: 1.125rem;
+  margin-left: auto;
+}
+
+.payments-history,
+.payments-notes {
+  margin-top: 1rem;
+}
+
+.payments-history__title,
+.payments-notes__title {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.payments-notes p {
+  margin: 0.25rem 0;
+  color: var(--text-muted, #6b7280);
+  font-size: 0.9rem;
+}
+
+.page-tab__dot {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background-color: var(--red-500, #ef4444);
+  margin-left: 0.4rem;
+  vertical-align: middle;
+}

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -1,0 +1,73 @@
+class PaymentsController < ApplicationController
+  PAYABLE_CLASSES = [PerformanceCompetition, SpeedSkydivingCompetition, Tournament].freeze
+
+  before_action :authenticate_user!
+  before_action :set_payable
+  before_action :authorize_payable!
+
+  def show
+    @paid_seats = @payable.paid_seats
+    @competitors_count = @payable.competitors.count
+    @seat_payments = @payable.seat_payments.includes(:pay_charge)
+    assign_event_ivar
+  end
+
+  def create
+    seats = params[:seats].to_i
+
+    if seats < 1
+      redirect_to polymorphic_path([@payable, :payments]),
+                  alert: t('event_payments.errors.invalid_seats')
+      return
+    end
+
+    checkout_session = current_user.payment_processor.checkout(
+      mode: 'payment',
+      line_items: [{
+        price_data: {
+          currency: 'usd',
+          product_data: {
+            name: t('event_payments.product_name', event: @payable.name)
+          },
+          unit_amount: EventSeatPayment::SEAT_PRICE_CENTS
+        },
+        quantity: seats
+      }],
+      payment_intent_data: {
+        metadata: {
+          type: EventSeatPayment::CHARGE_TYPE,
+          event_type: @payable.class.name,
+          event_id: @payable.id,
+          seats: seats
+        }
+      },
+      success_url: polymorphic_url([:success, @payable, :payments]),
+      cancel_url: polymorphic_url([@payable, :payments])
+    )
+
+    redirect_to checkout_session.url, allow_other_host: true, status: :see_other
+  end
+
+  def success
+    redirect_to polymorphic_path([@payable, :payments]), notice: t('event_payments.success')
+  end
+
+  private
+
+  def assign_event_ivar
+    @event = @payable
+    @tournament = @payable
+  end
+
+  def set_payable
+    @payable = payable_class.find(params["#{payable_class.name.underscore}_id"])
+  end
+
+  def payable_class
+    @payable_class ||= PAYABLE_CLASSES.detect { |c| params["#{c.name.underscore}_id"] }
+  end
+
+  def authorize_payable!
+    respond_not_authorized unless @payable.editable? && @payable.billable?
+  end
+end

--- a/app/javascript/controllers/payments_buy_controller.js
+++ b/app/javascript/controllers/payments_buy_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['seats', 'total']
+  static values = { priceCents: Number }
+
+  updateTotal() {
+    const seats = parseInt(this.seatsTarget.value, 10)
+    const safeSeats = Number.isNaN(seats) || seats < 1 ? 1 : seats
+    const totalUsd = (safeSeats * this.priceCentsValue) / 100
+    this.totalTarget.textContent = `$${totalUsd.toFixed(2)}`
+  }
+}

--- a/app/models/concerns/event_payable.rb
+++ b/app/models/concerns/event_payable.rb
@@ -1,0 +1,26 @@
+module EventPayable
+  extend ActiveSupport::Concern
+
+  BILLING_STARTS_AT = Date.new(2026, 4, 30)
+
+  included do
+    has_many :seat_payments,
+             -> { order(created_at: :desc) },
+             as: :payable,
+             class_name: 'EventSeatPayment',
+             dependent: :destroy,
+             inverse_of: :payable
+  end
+
+  def paid_seats
+    seat_payments.sum(:seats)
+  end
+
+  def seats_underpaid?
+    paid_seats < competitors.count
+  end
+
+  def billable?
+    starts_at.present? && starts_at > BILLING_STARTS_AT
+  end
+end

--- a/app/models/concerns/pay/charge_extensions.rb
+++ b/app/models/concerns/pay/charge_extensions.rb
@@ -5,6 +5,7 @@ module Pay
     included do
       after_save :update_owner_subscribed_status_for_lifetime
       after_save :process_gift_subscription
+      after_save :process_event_seat_payment
       after_destroy :update_owner_subscribed_status_for_lifetime
     end
 
@@ -35,6 +36,12 @@ module Pay
       )
 
       GiftSubscriptionMailer.gift_received(gifted).deliver_later
+    end
+
+    def process_event_seat_payment
+      return unless metadata&.dig('type') == EventSeatPayment::CHARGE_TYPE
+
+      EventSeatPayment.reconcile_from_charge(self)
     end
 
     def gift_charge?

--- a/app/models/event_seat_payment.rb
+++ b/app/models/event_seat_payment.rb
@@ -1,0 +1,16 @@
+class EventSeatPayment < ApplicationRecord
+  SEAT_PRICE_CENTS = 1500
+  CHARGE_TYPE = 'event_seats'.freeze
+
+  enum :kind, { purchase: 'purchase', refund: 'refund' }, suffix: true
+
+  belongs_to :payable, polymorphic: true
+  belongs_to :pay_charge, class_name: 'Pay::Charge'
+
+  validates :seats, :amount_cents, presence: true
+  validates :seats, numericality: { other_than: 0 }
+
+  def self.reconcile_from_charge(pay_charge)
+    Reconciler.new(pay_charge).call
+  end
+end

--- a/app/models/event_seat_payment/reconciler.rb
+++ b/app/models/event_seat_payment/reconciler.rb
@@ -1,0 +1,73 @@
+class EventSeatPayment::Reconciler
+  def initialize(pay_charge)
+    @pay_charge = pay_charge
+  end
+
+  def call
+    return unless event_seat_charge?
+    return unless event
+
+    ensure_purchase_row
+    ensure_refund_rows
+  end
+
+  private
+
+  attr_reader :pay_charge
+
+  def event_seat_charge?
+    pay_charge.metadata&.dig('type') == EventSeatPayment::CHARGE_TYPE
+  end
+
+  def event
+    @event ||= begin
+      type = pay_charge.metadata['event_type']
+      id = pay_charge.metadata['event_id']
+      klass = type.safe_constantize
+      klass&.find_by(id: id)
+    end
+  end
+
+  def ensure_purchase_row
+    return if EventSeatPayment.exists?(pay_charge_id: pay_charge.id, kind: 'purchase')
+
+    seats = pay_charge.metadata['seats'].to_i
+    return if seats <= 0
+
+    EventSeatPayment.create!(
+      payable: event,
+      pay_charge: pay_charge,
+      seats: seats,
+      amount_cents: seats * EventSeatPayment::SEAT_PRICE_CENTS,
+      kind: 'purchase'
+    )
+  end
+
+  def ensure_refund_rows
+    refunds = Array(pay_charge.data&.dig('refunds', 'data')).presence ||
+              Array(pay_charge.object&.dig('refunds', 'data'))
+
+    refunds.each { |refund| record_refund(refund) }
+  end
+
+  def record_refund(refund)
+    refund_id = refund['id']
+    return if refund_id.blank?
+    return if EventSeatPayment.exists?(stripe_refund_id: refund_id)
+
+    amount_cents = refund['amount'].to_i
+    return if amount_cents <= 0
+
+    seats_refunded = amount_cents / EventSeatPayment::SEAT_PRICE_CENTS
+    return if seats_refunded <= 0
+
+    EventSeatPayment.create!(
+      payable: event,
+      pay_charge: pay_charge,
+      seats: -seats_refunded,
+      amount_cents: -amount_cents,
+      kind: 'refund',
+      stripe_refund_id: refund_id
+    )
+  end
+end

--- a/app/models/performance_competition.rb
+++ b/app/models/performance_competition.rb
@@ -2,7 +2,7 @@ class PerformanceCompetition < ApplicationRecord
   self.table_name = :events
   default_scope -> { where(rules: :speed_distance_time) }
 
-  include Event::Permissions, Event::TrackVisibility, DesignatedLane, CompetitorsCopy, ResultsCopy
+  include Event::Permissions, Event::TrackVisibility, EventPayable, DesignatedLane, CompetitorsCopy, ResultsCopy
 
   enum :status, { draft: 0, published: 1, finished: 2, surprise: 3 }
   enum :rules, { speed_distance_time: 0 }, default: :speed_distance_time

--- a/app/models/speed_skydiving_competition.rb
+++ b/app/models/speed_skydiving_competition.rb
@@ -1,5 +1,5 @@
 class SpeedSkydivingCompetition < ApplicationRecord
-  include Event::TrackVisibility, Event::Permissions
+  include Event::TrackVisibility, Event::Permissions, EventPayable
 
   enum :status, { draft: 0, published: 1, finished: 2, surprise: 3 }
   enum :visibility, { public_event: 0, unlisted_event: 1, private_event: 2 }

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -22,6 +22,8 @@
 #
 
 class Tournament < ApplicationRecord
+  include EventPayable
+
   enum :status, { draft: 0, published: 1, finished: 2, surprise: 3 }
   enum :discipline, {
     time: 0,
@@ -53,6 +55,12 @@ class Tournament < ApplicationRecord
   after_initialize :set_default_values
 
   def active? = starts_at < Time.zone.now && !finished?
+
+  def editable?(user = Current.user)
+    return false unless user&.registered?
+
+    user.admin? || user == responsible || organizers.exists?(user:)
+  end
 
   # For compatibility with Event
   def finished? = false

--- a/app/views/payments/show.html.erb
+++ b/app/views/payments/show.html.erb
@@ -1,0 +1,91 @@
+<% provide :title, "#{@payable.name} - #{t('event_payments.title')}" %>
+
+<div class="show-page">
+  <%= render "#{@payable.class.name.underscore.pluralize}/header", editable: true %>
+
+  <div class="show-page-content">
+    <% underpaid = @paid_seats < @competitors_count %>
+    <% default_seats = underpaid ? (@competitors_count - @paid_seats) : 1 %>
+
+    <div class="card payments-status payments-status--<%= underpaid ? 'underpaid' : 'ok' %>">
+      <div class="payments-status__primary">
+        <%= t('event_payments.paid_for_seats', count: @paid_seats) %>
+      </div>
+      <% if underpaid %>
+        <div class="payments-status__secondary">
+          <%= t('event_payments.competitors_registered', count: @competitors_count) %>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="card payments-buy">
+      <h3 class="payments-buy__title"><%= t('event_payments.buy_title') %></h3>
+      <p class="payments-buy__price">
+        <%= t('event_payments.price_per_seat',
+              price: number_to_currency(EventSeatPayment::SEAT_PRICE_CENTS / 100.0)) %>
+      </p>
+      <%= form_with url: polymorphic_path([@payable, :payments]),
+                    method: :post,
+                    class: 'payments-buy__form',
+                    data: {
+                      controller: 'payments-buy',
+                      payments_buy_price_cents_value: EventSeatPayment::SEAT_PRICE_CENTS
+                    } do |f| %>
+        <%= f.label :seats, t('event_payments.seats_label'), class: 'payments-buy__label' %>
+        <%= f.number_field :seats,
+                           value: default_seats,
+                           min: 1,
+                           step: 1,
+                           required: true,
+                           class: 'payments-buy__input',
+                           data: {
+                             payments_buy_target: 'seats',
+                             action: 'input->payments-buy#updateTotal'
+                           } %>
+        <span class="payments-buy__total" data-payments-buy-target="total">
+          <%= number_to_currency(default_seats * EventSeatPayment::SEAT_PRICE_CENTS / 100.0) %>
+        </span>
+        <%= f.submit t('event_payments.buy_button'), class: 'button primary' %>
+      <% end %>
+    </div>
+
+    <% if @seat_payments.any? %>
+      <div class="card payments-history">
+        <h3 class="payments-history__title"><%= t('event_payments.history_title') %></h3>
+        <div class="table">
+          <div class="thead">
+            <div class="tr">
+              <div class="th"><%= t('event_payments.history.date') %></div>
+              <div class="th"><%= t('event_payments.history.kind') %></div>
+              <div class="th"><%= t('event_payments.history.seats') %></div>
+              <div class="th"><%= t('event_payments.history.amount') %></div>
+              <div class="th"><%= t('event_payments.history.receipt') %></div>
+            </div>
+          </div>
+          <div class="tbody">
+            <% @seat_payments.each do |payment| %>
+              <div class="tr">
+                <div class="td"><%= l(payment.created_at, format: :long) %></div>
+                <div class="td"><%= t("event_payments.kinds.#{payment.kind}") %></div>
+                <div class="td"><%= payment.seats %></div>
+                <div class="td"><%= number_to_currency(payment.amount_cents / 100.0) %></div>
+                <div class="td">
+                  <% receipt_url = payment.pay_charge.data&.dig('receipt_url') ||
+                                   payment.pay_charge.object&.dig('receipt_url') %>
+                  <% if receipt_url.present? %>
+                    <%= link_to t('event_payments.history.view_receipt'), receipt_url, target: '_blank', rel: 'noopener' %>
+                  <% end %>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+
+    <div class="card payments-notes">
+      <h3 class="payments-notes__title"><%= t('event_payments.notes_title') %></h3>
+      <p><%= t('event_payments.contact_note_html', email: mail_to('aleksandr@skyderby.io')) %></p>
+    </div>
+  </div>
+</div>

--- a/app/views/performance_competitions/_header.html.erb
+++ b/app/views/performance_competitions/_header.html.erb
@@ -68,6 +68,13 @@
     <% end %>
 
     <% if editable %>
+      <% if @event.billable? %>
+        <%= link_to performance_competition_payments_path(@event), class: ['page-tab', ('page-tab-active' if controller_path == 'payments')] do %>
+          <%= t('event_payments.tab') %>
+          <% if @event.seats_underpaid? %><span class="page-tab__dot" aria-hidden="true"></span><% end %>
+        <% end %>
+      <% end %>
+
       <%= link_to t('events.downloads'), performance_competition_downloads_path(@event), class: ['page-tab', ('page-tab-active' if controller_path == 'performance_competitions/downloads')] %>
 
       <%= link_to edit_performance_competition_path(@event), class: ['page-tab page-tab-right', ('page-tab-active' if current_page?(edit_performance_competition_path(@event)))] do %>

--- a/app/views/speed_skydiving_competitions/_header.html.erb
+++ b/app/views/speed_skydiving_competitions/_header.html.erb
@@ -28,6 +28,13 @@
     <% end %>
 
     <% if editable %>
+      <% if @event.billable? %>
+        <%= link_to speed_skydiving_competition_payments_path(@event), class: ['page-tab', ('page-tab-active' if current_page?(speed_skydiving_competition_payments_path(@event)))] do %>
+          <%= t('event_payments.tab') %>
+          <% if @event.seats_underpaid? %><span class="page-tab__dot" aria-hidden="true"></span><% end %>
+        <% end %>
+      <% end %>
+
       <%= link_to t('events.downloads'), speed_skydiving_competition_downloads_path(@event), class: ['page-tab', ('page-tab-active' if current_page?(speed_skydiving_competition_downloads_path(@event)))] %>
 
       <%= link_to edit_speed_skydiving_competition_path(@event), class: ['page-tab page-tab-right', ('page-tab-active' if current_page?(edit_speed_skydiving_competition_path(@event)))] do %>

--- a/app/views/tournaments/_header.html.erb
+++ b/app/views/tournaments/_header.html.erb
@@ -27,6 +27,13 @@
         Competitors
       <% end %>
 
+      <% if @tournament.billable? %>
+        <%= link_to tournament_payments_path(@tournament), class: ['page-tab', ('page-tab-active' if controller_path == 'payments')] do %>
+          <%= t('event_payments.tab') %>
+          <% if @tournament.seats_underpaid? %><span class="page-tab__dot" aria-hidden="true"></span><% end %>
+        <% end %>
+      <% end %>
+
       <%= link_to edit_tournament_path(@tournament), class: ['page-tab page-tab-right', ('page-tab-active' if controller_path == 'tournaments' && action_name == 'edit')] do %>
         <%= icon_tag 'gear-solid' %>
         <%= t('general.edit') %>

--- a/config/locales/event_payments.de.yml
+++ b/config/locales/event_payments.de.yml
@@ -1,0 +1,31 @@
+de:
+  event_payments:
+    tab: Zahlungen
+    title: Zahlungen
+    product_name: "Wettkampfplätze — %{event}"
+    paid_for_seats:
+      one: "1 Platz bezahlt"
+      other: "%{count} Plätze bezahlt"
+    competitors_registered:
+      one: "1 Teilnehmer registriert"
+      other: "%{count} Teilnehmer registriert"
+    buy_title: Plätze kaufen
+    price_per_seat: "%{price} pro Teilnehmer"
+    seats_label: Plätze
+    buy_button: Mit Stripe bezahlen
+    history_title: Zahlungsverlauf
+    history:
+      date: Datum
+      kind: Typ
+      seats: Plätze
+      amount: Betrag
+      receipt: Beleg
+      view_receipt: Beleg anzeigen
+    kinds:
+      purchase: Kauf
+      refund: Erstattung
+    notes_title: Erstattungen & Rechnungen
+    contact_note_html: "Sie benötigen eine Rechnung mit Firmendaten? Oder eine Erstattung für ungenutzte Plätze? Schreiben Sie an %{email}, wir bearbeiten es manuell."
+    success: "Zahlung erhalten. Es kann einige Sekunden dauern, bis sie unten erscheint."
+    errors:
+      invalid_seats: "Bitte geben Sie eine Anzahl Plätze größer als null ein."

--- a/config/locales/event_payments.en.yml
+++ b/config/locales/event_payments.en.yml
@@ -1,0 +1,31 @@
+en:
+  event_payments:
+    tab: Payments
+    title: Payments
+    product_name: "Competition seats — %{event}"
+    paid_for_seats:
+      one: "Paid for 1 seat"
+      other: "Paid for %{count} seats"
+    competitors_registered:
+      one: "1 competitor registered"
+      other: "%{count} competitors registered"
+    buy_title: Buy seats
+    price_per_seat: "%{price} per competitor"
+    seats_label: Seats
+    buy_button: Pay with Stripe
+    history_title: Payment history
+    history:
+      date: Date
+      kind: Type
+      seats: Seats
+      amount: Amount
+      receipt: Receipt
+      view_receipt: View receipt
+    kinds:
+      purchase: Purchase
+      refund: Refund
+    notes_title: Refunds & invoices
+    contact_note_html: "Need an invoice with your company details? Or a refund for unused seats? Email %{email} and we'll process it manually."
+    success: "Payment received. It may take a few seconds to appear below."
+    errors:
+      invalid_seats: "Please enter a number of seats greater than zero."

--- a/config/locales/event_payments.es.yml
+++ b/config/locales/event_payments.es.yml
@@ -1,0 +1,31 @@
+es:
+  event_payments:
+    tab: Pagos
+    title: Pagos
+    product_name: "Plazas de competición — %{event}"
+    paid_for_seats:
+      one: "1 plaza pagada"
+      other: "%{count} plazas pagadas"
+    competitors_registered:
+      one: "1 competidor registrado"
+      other: "%{count} competidores registrados"
+    buy_title: Comprar plazas
+    price_per_seat: "%{price} por competidor"
+    seats_label: Plazas
+    buy_button: Pagar con Stripe
+    history_title: Historial de pagos
+    history:
+      date: Fecha
+      kind: Tipo
+      seats: Plazas
+      amount: Importe
+      receipt: Recibo
+      view_receipt: Ver recibo
+    kinds:
+      purchase: Compra
+      refund: Reembolso
+    notes_title: Reembolsos y facturas
+    contact_note_html: "¿Necesitas una factura con los datos de tu empresa? ¿O un reembolso por plazas no usadas? Escribe a %{email} y lo gestionaremos manualmente."
+    success: "Pago recibido. Puede tardar unos segundos en aparecer abajo."
+    errors:
+      invalid_seats: "Introduce un número de plazas mayor que cero."

--- a/config/locales/event_payments.fr.yml
+++ b/config/locales/event_payments.fr.yml
@@ -1,0 +1,31 @@
+fr:
+  event_payments:
+    tab: Paiements
+    title: Paiements
+    product_name: "Places de compétition — %{event}"
+    paid_for_seats:
+      one: "1 place payée"
+      other: "%{count} places payées"
+    competitors_registered:
+      one: "1 concurrent inscrit"
+      other: "%{count} concurrents inscrits"
+    buy_title: Acheter des places
+    price_per_seat: "%{price} par concurrent"
+    seats_label: Places
+    buy_button: Payer avec Stripe
+    history_title: Historique des paiements
+    history:
+      date: Date
+      kind: Type
+      seats: Places
+      amount: Montant
+      receipt: Reçu
+      view_receipt: Voir le reçu
+    kinds:
+      purchase: Achat
+      refund: Remboursement
+    notes_title: Remboursements et factures
+    contact_note_html: "Besoin d'une facture avec les coordonnées de votre entreprise ? Ou d'un remboursement pour des places non utilisées ? Écrivez à %{email} et nous nous en occuperons manuellement."
+    success: "Paiement reçu. Il peut s'écouler quelques secondes avant qu'il n'apparaisse ci-dessous."
+    errors:
+      invalid_seats: "Veuillez saisir un nombre de places supérieur à zéro."

--- a/config/locales/event_payments.it.yml
+++ b/config/locales/event_payments.it.yml
@@ -1,0 +1,31 @@
+it:
+  event_payments:
+    tab: Pagamenti
+    title: Pagamenti
+    product_name: "Posti gara — %{event}"
+    paid_for_seats:
+      one: "1 posto pagato"
+      other: "%{count} posti pagati"
+    competitors_registered:
+      one: "1 concorrente iscritto"
+      other: "%{count} concorrenti iscritti"
+    buy_title: Acquista posti
+    price_per_seat: "%{price} per concorrente"
+    seats_label: Posti
+    buy_button: Paga con Stripe
+    history_title: Storico pagamenti
+    history:
+      date: Data
+      kind: Tipo
+      seats: Posti
+      amount: Importo
+      receipt: Ricevuta
+      view_receipt: Vedi ricevuta
+    kinds:
+      purchase: Acquisto
+      refund: Rimborso
+    notes_title: Rimborsi e fatture
+    contact_note_html: "Hai bisogno di una fattura con i dati della tua azienda? O di un rimborso per posti non utilizzati? Scrivi a %{email} e lo gestiremo manualmente."
+    success: "Pagamento ricevuto. Potrebbero servire alcuni secondi prima che appaia qui sotto."
+    errors:
+      invalid_seats: "Inserisci un numero di posti maggiore di zero."

--- a/config/locales/event_payments.ru.yml
+++ b/config/locales/event_payments.ru.yml
@@ -1,0 +1,35 @@
+ru:
+  event_payments:
+    tab: Оплата
+    title: Оплата
+    product_name: "Места участников — %{event}"
+    paid_for_seats:
+      one: "Оплачено %{count} место"
+      few: "Оплачено %{count} места"
+      many: "Оплачено %{count} мест"
+      other: "Оплачено %{count} мест"
+    competitors_registered:
+      one: "Зарегистрирован %{count} участник"
+      few: "Зарегистрировано %{count} участника"
+      many: "Зарегистрировано %{count} участников"
+      other: "Зарегистрировано %{count} участников"
+    buy_title: Купить места
+    price_per_seat: "%{price} за участника"
+    seats_label: Мест
+    buy_button: Оплатить через Stripe
+    history_title: История платежей
+    history:
+      date: Дата
+      kind: Тип
+      seats: Мест
+      amount: Сумма
+      receipt: Чек
+      view_receipt: Открыть чек
+    kinds:
+      purchase: Оплата
+      refund: Возврат
+    notes_title: Возвраты и счета
+    contact_note_html: "Нужен счёт с реквизитами компании? Или возврат за неиспользованные места? Напишите %{email}, и мы оформим всё вручную."
+    success: "Платёж получен. Информация может появиться ниже через несколько секунд."
+    errors:
+      invalid_seats: "Введите количество мест больше нуля."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,12 @@ Skyderby::Application.routes.draw do
     resources :organizers, only: %i[new create destroy]
   end
 
+  concern :payable do
+    resource :payments, only: %i[show create] do
+      get :success, on: :collection
+    end
+  end
+
   namespace :api, module: :api, defaults: { format: :json } do
     namespace :v1, module: :v1 do
       resources :profiles, only: :show do
@@ -137,7 +143,7 @@ Skyderby::Application.routes.draw do
   resources :events, only: %i[index new show]
   resources :performance_competitions,
             path: 'events/performance',
-            concerns: %i[sponsorable organizable],
+            concerns: %i[sponsorable organizable payable],
             except: :index do
     scope module: :performance_competitions do
       resources :rounds, only: %i[create update destroy] do
@@ -225,7 +231,7 @@ Skyderby::Application.routes.draw do
 
   resources :speed_skydiving_competitions,
             path: '/events/speed_skydiving',
-            concerns: %i[sponsorable organizable],
+            concerns: %i[sponsorable organizable payable],
             except: :index do
     scope module: :speed_skydiving_competitions do
       resources :categories, except: %i[index show] do
@@ -370,7 +376,10 @@ Skyderby::Application.routes.draw do
   end
   resources :virtual_comp_results
 
-  resources :tournaments, path: 'events/tournaments', concerns: [:sponsorable, :organizable], except: :index do
+  resources :tournaments,
+            path: 'events/tournaments',
+            concerns: %i[sponsorable organizable payable],
+            except: :index do
     scope module: :tournaments do
       resource :qualification, only: :show do
         scope module: :qualifications do

--- a/db/migrate/20260504122251_create_event_seat_payments.rb
+++ b/db/migrate/20260504122251_create_event_seat_payments.rb
@@ -1,0 +1,25 @@
+class CreateEventSeatPayments < ActiveRecord::Migration[8.0]
+  def change
+    create_table :event_seat_payments do |t|
+      t.references :payable, polymorphic: true, null: false, index: true
+      t.references :pay_charge, null: false, foreign_key: { to_table: :pay_charges }
+      t.integer :seats, null: false
+      t.integer :amount_cents, null: false
+      t.string :kind, null: false
+      t.string :stripe_refund_id
+
+      t.timestamps
+    end
+
+    add_index :event_seat_payments,
+              %i[pay_charge_id kind],
+              unique: true,
+              where: "kind = 'purchase'",
+              name: 'index_event_seat_payments_unique_purchase'
+
+    add_index :event_seat_payments,
+              :stripe_refund_id,
+              unique: true,
+              where: 'stripe_refund_id IS NOT NULL'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_02_055101) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_04_122251) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "unaccent"
@@ -123,6 +123,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_02_055101) do
     t.integer "profile_id"
     t.timestamptz "updated_at"
     t.index ["event_id"], name: "index_event_rounds_on_event_id"
+  end
+
+  create_table "event_seat_payments", force: :cascade do |t|
+    t.integer "amount_cents", null: false
+    t.datetime "created_at", null: false
+    t.string "kind", null: false
+    t.bigint "pay_charge_id", null: false
+    t.bigint "payable_id", null: false
+    t.string "payable_type", null: false
+    t.integer "seats", null: false
+    t.string "stripe_refund_id"
+    t.datetime "updated_at", null: false
+    t.index ["pay_charge_id", "kind"], name: "index_event_seat_payments_unique_purchase", unique: true, where: "((kind)::text = 'purchase'::text)"
+    t.index ["pay_charge_id"], name: "index_event_seat_payments_on_pay_charge_id"
+    t.index ["payable_type", "payable_id"], name: "index_event_seat_payments_on_payable"
+    t.index ["stripe_refund_id"], name: "index_event_seat_payments_on_stripe_refund_id", unique: true, where: "(stripe_refund_id IS NOT NULL)"
   end
 
   create_table "event_sections", id: :serial, force: :cascade do |t|
@@ -874,6 +890,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_02_055101) do
   add_foreign_key "event_competitors", "event_teams", column: "team_id"
   add_foreign_key "event_competitors", "profiles"
   add_foreign_key "event_results", "tracks"
+  add_foreign_key "event_seat_payments", "pay_charges"
   add_foreign_key "event_teams", "countries"
   add_foreign_key "free_pro_views", "tracks"
   add_foreign_key "free_pro_views", "users"

--- a/test/controllers/payments_controller_test.rb
+++ b/test/controllers/payments_controller_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class PaymentsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = speed_skydiving_competitions(:nationals)
+    @event.update!(starts_at: Date.new(2027, 1, 1))
+    @organizer = @event.responsible
+  end
+
+  test 'show forbids access for events that started before billing date' do
+    @event.update!(starts_at: Date.new(2020, 1, 1))
+    sign_in @organizer
+    get speed_skydiving_competition_payments_path(@event)
+    assert_response :forbidden
+  end
+
+  test 'show requires authentication' do
+    get speed_skydiving_competition_payments_path(@event)
+    assert_redirected_to new_user_session_path
+  end
+
+  test 'show forbids non-organizer' do
+    sign_in users(:regular_user)
+    get speed_skydiving_competition_payments_path(@event)
+    assert_response :forbidden
+  end
+
+  test 'show renders for organizer' do
+    sign_in @organizer
+    get speed_skydiving_competition_payments_path(@event)
+    assert_response :success
+  end
+
+  test 'create rejects zero or negative seats' do
+    sign_in @organizer
+    post speed_skydiving_competition_payments_path(@event), params: { seats: 0 }
+    assert_redirected_to speed_skydiving_competition_payments_path(@event)
+    follow_redirect!
+    assert_match(/greater than zero/i, flash[:alert] || @response.body)
+  end
+end

--- a/test/models/event_seat_payment_test.rb
+++ b/test/models/event_seat_payment_test.rb
@@ -1,0 +1,125 @@
+require 'test_helper'
+
+class EventSeatPaymentTest < ActiveSupport::TestCase
+  setup do
+    @event = speed_skydiving_competitions(:nationals)
+    @user = users(:regular_user)
+    @customer = Pay::Customer.create!(
+      owner: @user,
+      processor: 'stripe',
+      processor_id: "cus_test_#{SecureRandom.hex(4)}"
+    )
+  end
+
+  def build_charge(metadata:, processor_id: nil, amount: 1500, refunds: [])
+    Pay::Charge.create!(
+      customer: @customer,
+      processor_id: processor_id || "ch_test_#{SecureRandom.hex(6)}",
+      amount: amount,
+      currency: 'usd',
+      amount_refunded: refunds.sum { |r| r['amount'] },
+      data: { 'refunds' => { 'data' => refunds } },
+      metadata: metadata
+    )
+  end
+
+  test 'reconciler creates a purchase row for a paid charge' do
+    assert_difference -> { EventSeatPayment.count } => 1 do
+      build_charge(
+        metadata: {
+          'type' => 'event_seats',
+          'event_type' => 'SpeedSkydivingCompetition',
+          'event_id' => @event.id,
+          'seats' => 3
+        },
+        amount: 4500
+      )
+    end
+
+    payment = EventSeatPayment.last
+    assert_equal 'purchase', payment.kind
+    assert_equal 3, payment.seats
+    assert_equal 4500, payment.amount_cents
+    assert_equal @event, payment.payable
+  end
+
+  test 'reconciler is idempotent on repeated saves' do
+    charge = build_charge(
+      metadata: {
+        'type' => 'event_seats',
+        'event_type' => 'SpeedSkydivingCompetition',
+        'event_id' => @event.id,
+        'seats' => 2
+      },
+      amount: 3000
+    )
+
+    assert_no_difference -> { EventSeatPayment.where(kind: 'purchase').count } do
+      charge.update!(amount_refunded: 0)
+      charge.touch
+    end
+  end
+
+  test 'reconciler ignores non-event_seats charges' do
+    assert_no_difference -> { EventSeatPayment.count } do
+      build_charge(metadata: { 'type' => 'lifetime' }, amount: 5900)
+    end
+  end
+
+  test 'reconciler records refund as negative seats' do
+    refund = { 'id' => 're_test_123', 'amount' => 1500 }
+    charge = build_charge(
+      metadata: {
+        'type' => 'event_seats',
+        'event_type' => 'SpeedSkydivingCompetition',
+        'event_id' => @event.id,
+        'seats' => 3
+      },
+      amount: 4500
+    )
+
+    assert_difference -> { EventSeatPayment.where(kind: 'refund').count } => 1 do
+      charge.data = { 'refunds' => { 'data' => [refund] } }
+      charge.amount_refunded = 1500
+      charge.save!
+    end
+
+    refund_row = EventSeatPayment.find_by(stripe_refund_id: 're_test_123')
+    assert_equal(-1, refund_row.seats)
+    assert_equal(-1500, refund_row.amount_cents)
+  end
+
+  test 'reconciler is idempotent on repeated refund webhooks' do
+    refund = { 'id' => 're_test_999', 'amount' => 1500 }
+    charge = build_charge(
+      metadata: {
+        'type' => 'event_seats',
+        'event_type' => 'SpeedSkydivingCompetition',
+        'event_id' => @event.id,
+        'seats' => 3
+      },
+      amount: 4500,
+      refunds: [refund]
+    )
+
+    assert_no_difference -> { EventSeatPayment.where(kind: 'refund').count } do
+      charge.touch
+      charge.save!
+    end
+  end
+
+  test 'paid_seats sums purchases and refunds' do
+    build_charge(
+      metadata: {
+        'type' => 'event_seats',
+        'event_type' => 'SpeedSkydivingCompetition',
+        'event_id' => @event.id,
+        'seats' => 5
+      },
+      amount: 7500,
+      refunds: [{ 'id' => 're_x', 'amount' => 3000 }]
+    )
+
+    assert_equal 3, @event.paid_seats
+  end
+end


### PR DESCRIPTION
## Summary

- New **Payments** tab on speed skydiving, performance, and tournament events lets organizers pre-pay $15/seat via Stripe Checkout
- Tab is visible only to organizers and only for events starting after 2026-04-30; shows a red dot when paid seats < registered competitors (no dot when overpaid)
- Status card shows "Paid for X seats" (green) or adds "Y competitors registered" (red) when underpaid; buy form prefills with the deficit
- Payment history table with receipt links; partial refunds issued from the Stripe dashboard reconcile automatically into negative-seat rows via the `charge.refunded` webhook

## How it works

- New `event_seat_payments` join table is the source of truth; `paid_seats = SUM(seats)` (positives for purchases, negatives for refunds)
- Hooked into existing `Pay::ChargeExtensions` `after_save`: when a `Pay::Charge` arrives with `metadata['type'] == 'event_seats'`, the Reconciler writes a purchase row (idempotent on `pay_charge_id`) and one refund row per refund (idempotent on `stripe_refund_id`)
- Single shared `PaymentsController` (mirrors `OrganizersController` pattern) gated by `editable? && billable?`
- Stripe Checkout URL built with `current_user.payment_processor.checkout(mode: 'payment', ...)` mirroring the gift-subscription flow

## Stripe-side configuration required

Subscribe the existing `/pay/webhooks/stripe` endpoint to `charge.refunded` (in addition to whatever subscription events are already on). Without it, refunds won't reconcile back into the app. Receipt URLs in payment history depend on Stripe's "Successful payments" email setting being enabled.

## Test plan

- [ ] Tab is hidden for non-organizers
- [ ] Tab is hidden for organizers when `starts_at <= 2026-04-30`
- [ ] Tab is visible with red dot when paid seats < competitors
- [ ] Tab is visible without dot when paid seats >= competitors
- [ ] Buy form prefills with deficit when underpaid, with `1` otherwise; live total updates as the input changes
- [ ] Stripe Checkout redirect works in test mode (card `4242 4242 4242 4242`); after redirect, payment history shows the purchase row within seconds
- [ ] Issuing a partial refund from the Stripe dashboard adds a negative-seat row in payment history and reduces `paid_seats`
- [ ] Direct URL access to `/payments` is forbidden when event isn't billable
- [ ] All 6 locales render the page without missing translations
- [ ] `bin/rails test` and `bundle exec rubocop` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)