### PR TITLE
Align scoreboard score/total typography

### DIFF
--- a/app/assets/stylesheets/_scoreboards.css
+++ b/app/assets/stylesheets/_scoreboards.css
@@ -156,19 +156,26 @@
   padding: 0;
 }
 
+.scoreboard-table .result-show-cell,
+.scoreboard-table .result-upload-cell {
+  height: 100%;
+  width: 100%;
+}
+
 .scoreboard-table .result-show-cell {
   display: flex;
   align-items: center;
   justify-content: right;
   gap: 0.25rem;
-  height: 100%;
-  width: 100%;
 }
 
-.scoreboard-table .result-show-cell button {
+.scoreboard-table .result-show-cell button,
+.scoreboard-table a.result-show-cell,
+.scoreboard-table .result-upload-cell button,
+.scoreboard-table a.result-upload-cell {
+  font: inherit;
+  color: inherit;
   background-color: var(--white);
-  color: var(--gray-90);
-  text-align: right;
   border: 0;
   padding: 0.5rem;
   height: 100%;
@@ -177,28 +184,18 @@
   cursor: pointer;
 }
 
-.scoreboard-table .result-show-cell button:hover::before {
-  content: '';
-  background-color: var(--blue-70);
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
-}
-
+.scoreboard-table .result-show-cell button,
 .scoreboard-table a.result-show-cell {
-  background-color: var(--white);
-  color: var(--gray-90);
   text-align: right;
-  border: 0;
-  padding: 0.5rem;
-  height: 100%;
-  width: 100%;
-  position: relative;
-  cursor: pointer;
 }
 
+.scoreboard-table .result-upload-cell button,
+.scoreboard-table a.result-upload-cell {
+  color: var(--white);
+  font-size: 1.125rem;
+}
+
+.scoreboard-table .result-show-cell button:hover::before,
 .scoreboard-table a.result-show-cell:hover::before {
   content: '';
   background-color: var(--blue-70);
@@ -209,39 +206,7 @@
   height: 3px;
 }
 
-.scoreboard-table .result-upload-cell {
-  height: 100%;
-  width: 100%;
-}
-
-.scoreboard-table .result-upload-cell button {
-  background-color: var(--white);
-  border: 0;
-  padding: 0.5rem;
-  height: 100%;
-  width: 100%;
-  position: relative;
-  cursor: pointer;
-  color: var(--white);
-  font-size: 1.125rem;
-}
-
-.scoreboard-table .result-upload-cell button:hover {
-  background-color: var(--blue-70);
-}
-
-.scoreboard-table a.result-upload-cell {
-  background-color: var(--white);
-  border: 0;
-  padding: 0.5rem;
-  height: 100%;
-  width: 100%;
-  position: relative;
-  cursor: pointer;
-  color: var(--white);
-  font-size: 1.125rem;
-}
-
+.scoreboard-table .result-upload-cell button:hover,
 .scoreboard-table a.result-upload-cell:hover {
   background-color: var(--blue-70);
 }


### PR DESCRIPTION
## Summary

Score values in the scoreboard are rendered inside a `button` (because `button_to` wraps the value in a form-button), while the Total/Avg columns are plain `<td>` text. Browsers don't inherit `font-*` properties on form controls, so the score came out at the user-agent button default (~14px, slightly muted) while neighboring text inherited the body's 16px black. Same story for `color`: the button had explicit `color: var(--gray-90)` (#333) while td text fell through to default black.

This patch:

- Adds `font: inherit` and `color: inherit` to the scoreboard's clickable result-cell elements, so score, country, name, and Total/Avg all render with one set of typography.
- Collapses four near-identical CSS rule blocks (the `button` and `a`-variant of both `.result-show-cell` and `.result-upload-cell`) into one shared selector list.
- Keeps the existing `color: var(--white)` on `.result-upload-cell` — that one is intentional UX: the upload icon stays invisible against the white background until hover, when the cell turns blue.

Net result: `21 insertions, 56 deletions` — same visual behavior plus typography unification, less code.

## Test plan

- [ ] Score values, country code, and Total/Avg render with identical font-size/color in the scoreboard table
- [ ] Hovering a result cell still shows the blue 3px bottom indicator
- [ ] Empty result cells in editable mode still show the upload icon only on hover (white-on-white → white-on-blue transition preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)