### PR TITLE
Disable Turbo on payments form so Stripe Checkout redirect works

### DIFF
--- a/app/views/payments/show.html.erb
+++ b/app/views/payments/show.html.erb
@@ -28,6 +28,7 @@
                     method: :post,
                     class: 'payments-buy__form',
                     data: {
+                      turbo: false,
                       controller: 'payments-buy',
                       payments_buy_price_cents_value: EventSeatPayment::SEAT_PRICE_CENTS
                     } do |f| %>


### PR DESCRIPTION
## Summary

Clicking "Pay with Stripe" on `/<event>/payments` triggered a 403 in the browser console:

> Fetch API cannot load https://checkout.stripe.com/c/pay/cs_live_… due to access control checks.

Cause: the form is submitted via Turbo Drive, so when our controller responds with `redirect_to checkout_session.url, allow_other_host: true, status: :see_other`, Turbo tries to fetch the redirect target with an XHR instead of doing a top-level navigation. Stripe Checkout doesn't allow cross-origin requests, so the preflight returns 403 and the browser refuses to navigate.

The existing gift-subscription form solves the same problem with `data: { turbo: false }` ([gift_subscriptions/new.html.erb:13](app/views/gift_subscriptions/new.html.erb#L13)). Apply the same opt-out on the seats payment form so the browser does a normal POST → 303 redirect → top-level navigation to Stripe.

## Test plan

- [ ] Click "Pay with Stripe" on a competition payments page → browser navigates to `https://checkout.stripe.com/...` (no console errors)
- [ ] After completing/cancelling Checkout, return URL works and lands back on the payments page
- [ ] Form still validates `seats >= 1` server-side and rejects 0 / negative input

🤖 Generated with [Claude Code](https://claude.com/claude-code)