### PR TITLE
Rename seats → entries across payments feature

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -6,18 +6,18 @@ class PaymentsController < ApplicationController
   before_action :authorize_payable!
 
   def show
-    @paid_seats = @payable.paid_seats
+    @paid_entries = @payable.paid_entries
     @competitors_count = @payable.competitors.count
-    @seat_payments = @payable.seat_payments.includes(:pay_charge)
+    @entry_payments = @payable.entry_payments.includes(:pay_charge)
     assign_event_ivar
   end
 
   def create
-    seats = params[:seats].to_i
+    entries = params[:entries].to_i
 
-    if seats < 1
+    if entries < 1
       redirect_to polymorphic_path([@payable, :payments]),
-                  alert: t('event_payments.errors.invalid_seats')
+                  alert: t('event_payments.errors.invalid_entries')
       return
     end
 
@@ -29,16 +29,16 @@ class PaymentsController < ApplicationController
           product_data: {
             name: t('event_payments.product_name', event: @payable.name)
           },
-          unit_amount: EventSeatPayment::SEAT_PRICE_CENTS
+          unit_amount: EventEntryPayment::ENTRY_PRICE_CENTS
         },
-        quantity: seats
+        quantity: entries
       }],
       payment_intent_data: {
         metadata: {
-          type: EventSeatPayment::CHARGE_TYPE,
+          type: EventEntryPayment::CHARGE_TYPE,
           event_type: @payable.class.name,
           event_id: @payable.id,
-          seats: seats
+          entries: entries
         }
       },
       success_url: polymorphic_url([:success, @payable, :payments]),

--- a/app/javascript/controllers/payments_buy_controller.js
+++ b/app/javascript/controllers/payments_buy_controller.js
@@ -1,13 +1,13 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
-  static targets = ['seats', 'total']
+  static targets = ['entries', 'total']
   static values = { priceCents: Number }
 
   updateTotal() {
-    const seats = parseInt(this.seatsTarget.value, 10)
-    const safeSeats = Number.isNaN(seats) || seats < 1 ? 1 : seats
-    const totalUsd = (safeSeats * this.priceCentsValue) / 100
+    const entries = parseInt(this.entriesTarget.value, 10)
+    const safeEntries = Number.isNaN(entries) || entries < 1 ? 1 : entries
+    const totalUsd = (safeEntries * this.priceCentsValue) / 100
     this.totalTarget.textContent = `$${totalUsd.toFixed(2)}`
   }
 }

--- a/app/models/concerns/event_payable.rb
+++ b/app/models/concerns/event_payable.rb
@@ -4,20 +4,20 @@ module EventPayable
   BILLING_STARTS_AT = Date.new(2026, 4, 30)
 
   included do
-    has_many :seat_payments,
+    has_many :entry_payments,
              -> { order(created_at: :desc) },
              as: :payable,
-             class_name: 'EventSeatPayment',
+             class_name: 'EventEntryPayment',
              dependent: :destroy,
              inverse_of: :payable
   end
 
-  def paid_seats
-    seat_payments.sum(:seats)
+  def paid_entries
+    entry_payments.sum(:entries)
   end
 
-  def seats_underpaid?
-    paid_seats < competitors.count
+  def entries_underpaid?
+    paid_entries < competitors.count
   end
 
   def billable?

--- a/app/models/concerns/pay/charge_extensions.rb
+++ b/app/models/concerns/pay/charge_extensions.rb
@@ -5,7 +5,7 @@ module Pay
     included do
       after_save :update_owner_subscribed_status_for_lifetime
       after_save :process_gift_subscription
-      after_save :process_event_seat_payment
+      after_save :process_event_entry_payment
       after_destroy :update_owner_subscribed_status_for_lifetime
     end
 
@@ -38,10 +38,10 @@ module Pay
       GiftSubscriptionMailer.gift_received(gifted).deliver_later
     end
 
-    def process_event_seat_payment
-      return unless metadata&.dig('type') == EventSeatPayment::CHARGE_TYPE
+    def process_event_entry_payment
+      return unless metadata&.dig('type') == EventEntryPayment::CHARGE_TYPE
 
-      EventSeatPayment.reconcile_from_charge(self)
+      EventEntryPayment.reconcile_from_charge(self)
     end
 
     def gift_charge?

--- a/app/models/event_entry_payment.rb
+++ b/app/models/event_entry_payment.rb
@@ -1,14 +1,14 @@
-class EventSeatPayment < ApplicationRecord
-  SEAT_PRICE_CENTS = 1500
-  CHARGE_TYPE = 'event_seats'.freeze
+class EventEntryPayment < ApplicationRecord
+  ENTRY_PRICE_CENTS = 1500
+  CHARGE_TYPE = 'event_entries'.freeze
 
   enum :kind, { purchase: 'purchase', refund: 'refund' }, suffix: true
 
   belongs_to :payable, polymorphic: true
   belongs_to :pay_charge, class_name: 'Pay::Charge'
 
-  validates :seats, :amount_cents, presence: true
-  validates :seats, numericality: { other_than: 0 }
+  validates :entries, :amount_cents, presence: true
+  validates :entries, numericality: { other_than: 0 }
 
   def self.reconcile_from_charge(pay_charge)
     Reconciler.new(pay_charge).call

--- a/app/models/event_entry_payment/reconciler.rb
+++ b/app/models/event_entry_payment/reconciler.rb
@@ -1,10 +1,10 @@
-class EventSeatPayment::Reconciler
+class EventEntryPayment::Reconciler
   def initialize(pay_charge)
     @pay_charge = pay_charge
   end
 
   def call
-    return unless event_seat_charge?
+    return unless event_entries_charge?
     return unless event
 
     ensure_purchase_row
@@ -15,8 +15,8 @@ class EventSeatPayment::Reconciler
 
   attr_reader :pay_charge
 
-  def event_seat_charge?
-    pay_charge.metadata&.dig('type') == EventSeatPayment::CHARGE_TYPE
+  def event_entries_charge?
+    pay_charge.metadata&.dig('type') == EventEntryPayment::CHARGE_TYPE
   end
 
   def event
@@ -29,16 +29,16 @@ class EventSeatPayment::Reconciler
   end
 
   def ensure_purchase_row
-    return if EventSeatPayment.exists?(pay_charge_id: pay_charge.id, kind: 'purchase')
+    return if EventEntryPayment.exists?(pay_charge_id: pay_charge.id, kind: 'purchase')
 
-    seats = pay_charge.metadata['seats'].to_i
-    return if seats <= 0
+    entries = pay_charge.metadata['entries'].to_i
+    return if entries <= 0
 
-    EventSeatPayment.create!(
+    EventEntryPayment.create!(
       payable: event,
       pay_charge: pay_charge,
-      seats: seats,
-      amount_cents: seats * EventSeatPayment::SEAT_PRICE_CENTS,
+      entries: entries,
+      amount_cents: entries * EventEntryPayment::ENTRY_PRICE_CENTS,
       kind: 'purchase'
     )
   end
@@ -53,18 +53,18 @@ class EventSeatPayment::Reconciler
   def record_refund(refund)
     refund_id = refund['id']
     return if refund_id.blank?
-    return if EventSeatPayment.exists?(stripe_refund_id: refund_id)
+    return if EventEntryPayment.exists?(stripe_refund_id: refund_id)
 
     amount_cents = refund['amount'].to_i
     return if amount_cents <= 0
 
-    seats_refunded = amount_cents / EventSeatPayment::SEAT_PRICE_CENTS
-    return if seats_refunded <= 0
+    entries_refunded = amount_cents / EventEntryPayment::ENTRY_PRICE_CENTS
+    return if entries_refunded <= 0
 
-    EventSeatPayment.create!(
+    EventEntryPayment.create!(
       payable: event,
       pay_charge: pay_charge,
-      seats: -seats_refunded,
+      entries: -entries_refunded,
       amount_cents: -amount_cents,
       kind: 'refund',
       stripe_refund_id: refund_id

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -2,11 +2,10 @@
   <h1>Choose an event type</h1>
 
   <div class="notice">
-    Starting May 2025, the cost for scoring a competition is <b>$15 per competitor</b>.
+    The cost for scoring a competition is <b>$15 per competitor</b>.
+    Once the competition is created, payment is available on the <b>Payments</b> tab on the competition page.
     <br>
-    To ensure a seamless experience, please <a href="https://www.paypal.com/paypalme/AleksandrKuninUAE">complete your payment</a> before finishing the 3rd round of the competition.
-    <br>
-    Custom quotations are available. Feel free to <a href="mailto:skyksandr@gmail.com">reach out via email</a> for more details.
+    Custom quotations are available. Feel free to <a href="mailto:aleksandr@skyderby.io">reach out via email</a> for more details.
   </div>
 
   <div class="item">

--- a/app/views/payments/show.html.erb
+++ b/app/views/payments/show.html.erb
@@ -4,12 +4,12 @@
   <%= render "#{@payable.class.name.underscore.pluralize}/header", editable: true %>
 
   <div class="show-page-content">
-    <% underpaid = @paid_seats < @competitors_count %>
-    <% default_seats = underpaid ? (@competitors_count - @paid_seats) : 1 %>
+    <% underpaid = @paid_entries < @competitors_count %>
+    <% default_entries = underpaid ? (@competitors_count - @paid_entries) : 1 %>
 
     <div class="card payments-status payments-status--<%= underpaid ? 'underpaid' : 'ok' %>">
       <div class="payments-status__primary">
-        <%= t('event_payments.paid_for_seats', count: @paid_seats) %>
+        <%= t('event_payments.paid_for_entries', count: @paid_entries) %>
       </div>
       <% if underpaid %>
         <div class="payments-status__secondary">
@@ -21,8 +21,8 @@
     <div class="card payments-buy">
       <h3 class="payments-buy__title"><%= t('event_payments.buy_title') %></h3>
       <p class="payments-buy__price">
-        <%= t('event_payments.price_per_seat',
-              price: number_to_currency(EventSeatPayment::SEAT_PRICE_CENTS / 100.0)) %>
+        <%= t('event_payments.price_per_entry',
+              price: number_to_currency(EventEntryPayment::ENTRY_PRICE_CENTS / 100.0)) %>
       </p>
       <%= form_with url: polymorphic_path([@payable, :payments]),
                     method: :post,
@@ -30,27 +30,27 @@
                     data: {
                       turbo: false,
                       controller: 'payments-buy',
-                      payments_buy_price_cents_value: EventSeatPayment::SEAT_PRICE_CENTS
+                      payments_buy_price_cents_value: EventEntryPayment::ENTRY_PRICE_CENTS
                     } do |f| %>
-        <%= f.label :seats, t('event_payments.seats_label'), class: 'payments-buy__label' %>
-        <%= f.number_field :seats,
-                           value: default_seats,
+        <%= f.label :entries, t('event_payments.entries_label'), class: 'payments-buy__label' %>
+        <%= f.number_field :entries,
+                           value: default_entries,
                            min: 1,
                            step: 1,
                            required: true,
                            class: 'payments-buy__input',
                            data: {
-                             payments_buy_target: 'seats',
+                             payments_buy_target: 'entries',
                              action: 'input->payments-buy#updateTotal'
                            } %>
         <span class="payments-buy__total" data-payments-buy-target="total">
-          <%= number_to_currency(default_seats * EventSeatPayment::SEAT_PRICE_CENTS / 100.0) %>
+          <%= number_to_currency(default_entries * EventEntryPayment::ENTRY_PRICE_CENTS / 100.0) %>
         </span>
         <%= f.submit t('event_payments.buy_button'), class: 'button primary' %>
       <% end %>
     </div>
 
-    <% if @seat_payments.any? %>
+    <% if @entry_payments.any? %>
       <div class="card payments-history">
         <h3 class="payments-history__title"><%= t('event_payments.history_title') %></h3>
         <div class="table">
@@ -58,17 +58,17 @@
             <div class="tr">
               <div class="th"><%= t('event_payments.history.date') %></div>
               <div class="th"><%= t('event_payments.history.kind') %></div>
-              <div class="th"><%= t('event_payments.history.seats') %></div>
+              <div class="th"><%= t('event_payments.history.entries') %></div>
               <div class="th"><%= t('event_payments.history.amount') %></div>
               <div class="th"><%= t('event_payments.history.receipt') %></div>
             </div>
           </div>
           <div class="tbody">
-            <% @seat_payments.each do |payment| %>
+            <% @entry_payments.each do |payment| %>
               <div class="tr">
                 <div class="td"><%= l(payment.created_at, format: :long) %></div>
                 <div class="td"><%= t("event_payments.kinds.#{payment.kind}") %></div>
-                <div class="td"><%= payment.seats %></div>
+                <div class="td"><%= payment.entries %></div>
                 <div class="td"><%= number_to_currency(payment.amount_cents / 100.0) %></div>
                 <div class="td">
                   <% receipt_url = payment.pay_charge.data&.dig('receipt_url') ||

--- a/app/views/performance_competitions/_header.html.erb
+++ b/app/views/performance_competitions/_header.html.erb
@@ -71,7 +71,7 @@
       <% if @event.billable? %>
         <%= link_to performance_competition_payments_path(@event), class: ['page-tab', ('page-tab-active' if controller_path == 'payments')] do %>
           <%= t('event_payments.tab') %>
-          <% if @event.seats_underpaid? %><span class="page-tab__dot" aria-hidden="true"></span><% end %>
+          <% if @event.entries_underpaid? %><span class="page-tab__dot" aria-hidden="true"></span><% end %>
         <% end %>
       <% end %>
 

--- a/app/views/speed_skydiving_competitions/_header.html.erb
+++ b/app/views/speed_skydiving_competitions/_header.html.erb
@@ -31,7 +31,7 @@
       <% if @event.billable? %>
         <%= link_to speed_skydiving_competition_payments_path(@event), class: ['page-tab', ('page-tab-active' if current_page?(speed_skydiving_competition_payments_path(@event)))] do %>
           <%= t('event_payments.tab') %>
-          <% if @event.seats_underpaid? %><span class="page-tab__dot" aria-hidden="true"></span><% end %>
+          <% if @event.entries_underpaid? %><span class="page-tab__dot" aria-hidden="true"></span><% end %>
         <% end %>
       <% end %>
 

--- a/app/views/tournaments/_header.html.erb
+++ b/app/views/tournaments/_header.html.erb
@@ -30,7 +30,7 @@
       <% if @tournament.billable? %>
         <%= link_to tournament_payments_path(@tournament), class: ['page-tab', ('page-tab-active' if controller_path == 'payments')] do %>
           <%= t('event_payments.tab') %>
-          <% if @tournament.seats_underpaid? %><span class="page-tab__dot" aria-hidden="true"></span><% end %>
+          <% if @tournament.entries_underpaid? %><span class="page-tab__dot" aria-hidden="true"></span><% end %>
         <% end %>
       <% end %>
 

--- a/config/locales/event_payments.de.yml
+++ b/config/locales/event_payments.de.yml
@@ -2,22 +2,22 @@ de:
   event_payments:
     tab: Zahlungen
     title: Zahlungen
-    product_name: "Wettkampfplätze — %{event}"
-    paid_for_seats:
-      one: "1 Platz bezahlt"
-      other: "%{count} Plätze bezahlt"
+    product_name: "Wettkampfanmeldungen — %{event}"
+    paid_for_entries:
+      one: "1 Anmeldung bezahlt"
+      other: "%{count} Anmeldungen bezahlt"
     competitors_registered:
       one: "1 Teilnehmer registriert"
       other: "%{count} Teilnehmer registriert"
-    buy_title: Plätze kaufen
-    price_per_seat: "%{price} pro Teilnehmer"
-    seats_label: Plätze
+    buy_title: Anmeldungen kaufen
+    price_per_entry: "%{price} pro Teilnehmer"
+    entries_label: Anmeldungen
     buy_button: Mit Stripe bezahlen
     history_title: Zahlungsverlauf
     history:
       date: Datum
       kind: Typ
-      seats: Plätze
+      entries: Anmeldungen
       amount: Betrag
       receipt: Beleg
       view_receipt: Beleg anzeigen
@@ -25,7 +25,7 @@ de:
       purchase: Kauf
       refund: Erstattung
     notes_title: Erstattungen & Rechnungen
-    contact_note_html: "Sie benötigen eine Rechnung mit Firmendaten? Oder eine Erstattung für ungenutzte Plätze? Schreiben Sie an %{email}, wir bearbeiten es manuell."
+    contact_note_html: "Sie benötigen eine Rechnung mit Firmendaten? Oder eine Erstattung für ungenutzte Anmeldungen? Schreiben Sie an %{email}, wir bearbeiten es manuell."
     success: "Zahlung erhalten. Es kann einige Sekunden dauern, bis sie unten erscheint."
     errors:
-      invalid_seats: "Bitte geben Sie eine Anzahl Plätze größer als null ein."
+      invalid_entries: "Bitte geben Sie eine Anzahl Anmeldungen größer als null ein."

--- a/config/locales/event_payments.en.yml
+++ b/config/locales/event_payments.en.yml
@@ -2,22 +2,22 @@ en:
   event_payments:
     tab: Payments
     title: Payments
-    product_name: "Competition seats — %{event}"
-    paid_for_seats:
-      one: "Paid for 1 seat"
-      other: "Paid for %{count} seats"
+    product_name: "Competition entries — %{event}"
+    paid_for_entries:
+      one: "Paid for 1 entry"
+      other: "Paid for %{count} entries"
     competitors_registered:
       one: "1 competitor registered"
       other: "%{count} competitors registered"
-    buy_title: Buy seats
-    price_per_seat: "%{price} per competitor"
-    seats_label: Seats
+    buy_title: Buy entries
+    price_per_entry: "%{price} per competitor"
+    entries_label: Entries
     buy_button: Pay with Stripe
     history_title: Payment history
     history:
       date: Date
       kind: Type
-      seats: Seats
+      entries: Entries
       amount: Amount
       receipt: Receipt
       view_receipt: View receipt
@@ -25,7 +25,7 @@ en:
       purchase: Purchase
       refund: Refund
     notes_title: Refunds & invoices
-    contact_note_html: "Need an invoice with your company details? Or a refund for unused seats? Email %{email} and we'll process it manually."
+    contact_note_html: "Need an invoice with your company details? Or a refund for unused entries? Email %{email} and we'll process it manually."
     success: "Payment received. It may take a few seconds to appear below."
     errors:
-      invalid_seats: "Please enter a number of seats greater than zero."
+      invalid_entries: "Please enter a number of entries greater than zero."

--- a/config/locales/event_payments.es.yml
+++ b/config/locales/event_payments.es.yml
@@ -2,22 +2,22 @@ es:
   event_payments:
     tab: Pagos
     title: Pagos
-    product_name: "Plazas de competición — %{event}"
-    paid_for_seats:
-      one: "1 plaza pagada"
-      other: "%{count} plazas pagadas"
+    product_name: "Inscripciones de competición — %{event}"
+    paid_for_entries:
+      one: "1 inscripción pagada"
+      other: "%{count} inscripciones pagadas"
     competitors_registered:
       one: "1 competidor registrado"
       other: "%{count} competidores registrados"
-    buy_title: Comprar plazas
-    price_per_seat: "%{price} por competidor"
-    seats_label: Plazas
+    buy_title: Comprar inscripciones
+    price_per_entry: "%{price} por competidor"
+    entries_label: Inscripciones
     buy_button: Pagar con Stripe
     history_title: Historial de pagos
     history:
       date: Fecha
       kind: Tipo
-      seats: Plazas
+      entries: Inscripciones
       amount: Importe
       receipt: Recibo
       view_receipt: Ver recibo
@@ -25,7 +25,7 @@ es:
       purchase: Compra
       refund: Reembolso
     notes_title: Reembolsos y facturas
-    contact_note_html: "¿Necesitas una factura con los datos de tu empresa? ¿O un reembolso por plazas no usadas? Escribe a %{email} y lo gestionaremos manualmente."
+    contact_note_html: "¿Necesitas una factura con los datos de tu empresa? ¿O un reembolso por inscripciones no usadas? Escribe a %{email} y lo gestionaremos manualmente."
     success: "Pago recibido. Puede tardar unos segundos en aparecer abajo."
     errors:
-      invalid_seats: "Introduce un número de plazas mayor que cero."
+      invalid_entries: "Introduce un número de inscripciones mayor que cero."

--- a/config/locales/event_payments.fr.yml
+++ b/config/locales/event_payments.fr.yml
@@ -2,22 +2,22 @@ fr:
   event_payments:
     tab: Paiements
     title: Paiements
-    product_name: "Places de compétition — %{event}"
-    paid_for_seats:
-      one: "1 place payée"
-      other: "%{count} places payées"
+    product_name: "Inscriptions de compétition — %{event}"
+    paid_for_entries:
+      one: "1 inscription payée"
+      other: "%{count} inscriptions payées"
     competitors_registered:
       one: "1 concurrent inscrit"
       other: "%{count} concurrents inscrits"
-    buy_title: Acheter des places
-    price_per_seat: "%{price} par concurrent"
-    seats_label: Places
+    buy_title: Acheter des inscriptions
+    price_per_entry: "%{price} par concurrent"
+    entries_label: Inscriptions
     buy_button: Payer avec Stripe
     history_title: Historique des paiements
     history:
       date: Date
       kind: Type
-      seats: Places
+      entries: Inscriptions
       amount: Montant
       receipt: Reçu
       view_receipt: Voir le reçu
@@ -25,7 +25,7 @@ fr:
       purchase: Achat
       refund: Remboursement
     notes_title: Remboursements et factures
-    contact_note_html: "Besoin d'une facture avec les coordonnées de votre entreprise ? Ou d'un remboursement pour des places non utilisées ? Écrivez à %{email} et nous nous en occuperons manuellement."
+    contact_note_html: "Besoin d'une facture avec les coordonnées de votre entreprise ? Ou d'un remboursement pour des inscriptions non utilisées ? Écrivez à %{email} et nous nous en occuperons manuellement."
     success: "Paiement reçu. Il peut s'écouler quelques secondes avant qu'il n'apparaisse ci-dessous."
     errors:
-      invalid_seats: "Veuillez saisir un nombre de places supérieur à zéro."
+      invalid_entries: "Veuillez saisir un nombre d'inscriptions supérieur à zéro."

--- a/config/locales/event_payments.it.yml
+++ b/config/locales/event_payments.it.yml
@@ -2,22 +2,22 @@ it:
   event_payments:
     tab: Pagamenti
     title: Pagamenti
-    product_name: "Posti gara — %{event}"
-    paid_for_seats:
-      one: "1 posto pagato"
-      other: "%{count} posti pagati"
+    product_name: "Iscrizioni gara — %{event}"
+    paid_for_entries:
+      one: "1 iscrizione pagata"
+      other: "%{count} iscrizioni pagate"
     competitors_registered:
       one: "1 concorrente iscritto"
       other: "%{count} concorrenti iscritti"
-    buy_title: Acquista posti
-    price_per_seat: "%{price} per concorrente"
-    seats_label: Posti
+    buy_title: Acquista iscrizioni
+    price_per_entry: "%{price} per concorrente"
+    entries_label: Iscrizioni
     buy_button: Paga con Stripe
     history_title: Storico pagamenti
     history:
       date: Data
       kind: Tipo
-      seats: Posti
+      entries: Iscrizioni
       amount: Importo
       receipt: Ricevuta
       view_receipt: Vedi ricevuta
@@ -25,7 +25,7 @@ it:
       purchase: Acquisto
       refund: Rimborso
     notes_title: Rimborsi e fatture
-    contact_note_html: "Hai bisogno di una fattura con i dati della tua azienda? O di un rimborso per posti non utilizzati? Scrivi a %{email} e lo gestiremo manualmente."
+    contact_note_html: "Hai bisogno di una fattura con i dati della tua azienda? O di un rimborso per iscrizioni non utilizzate? Scrivi a %{email} e lo gestiremo manualmente."
     success: "Pagamento ricevuto. Potrebbero servire alcuni secondi prima che appaia qui sotto."
     errors:
-      invalid_seats: "Inserisci un numero di posti maggiore di zero."
+      invalid_entries: "Inserisci un numero di iscrizioni maggiore di zero."

--- a/config/locales/event_payments.ru.yml
+++ b/config/locales/event_payments.ru.yml
@@ -2,26 +2,26 @@ ru:
   event_payments:
     tab: Оплата
     title: Оплата
-    product_name: "Места участников — %{event}"
-    paid_for_seats:
-      one: "Оплачено %{count} место"
-      few: "Оплачено %{count} места"
-      many: "Оплачено %{count} мест"
-      other: "Оплачено %{count} мест"
+    product_name: "Регистрации участников — %{event}"
+    paid_for_entries:
+      one: "Оплачена %{count} регистрация"
+      few: "Оплачено %{count} регистрации"
+      many: "Оплачено %{count} регистраций"
+      other: "Оплачено %{count} регистраций"
     competitors_registered:
       one: "Зарегистрирован %{count} участник"
       few: "Зарегистрировано %{count} участника"
       many: "Зарегистрировано %{count} участников"
       other: "Зарегистрировано %{count} участников"
-    buy_title: Купить места
-    price_per_seat: "%{price} за участника"
-    seats_label: Мест
+    buy_title: Купить регистрации
+    price_per_entry: "%{price} за участника"
+    entries_label: Регистраций
     buy_button: Оплатить через Stripe
     history_title: История платежей
     history:
       date: Дата
       kind: Тип
-      seats: Мест
+      entries: Регистраций
       amount: Сумма
       receipt: Чек
       view_receipt: Открыть чек
@@ -29,7 +29,7 @@ ru:
       purchase: Оплата
       refund: Возврат
     notes_title: Возвраты и счета
-    contact_note_html: "Нужен счёт с реквизитами компании? Или возврат за неиспользованные места? Напишите %{email}, и мы оформим всё вручную."
+    contact_note_html: "Нужен счёт с реквизитами компании? Или возврат за неиспользованные регистрации? Напишите %{email}, и мы оформим всё вручную."
     success: "Платёж получен. Информация может появиться ниже через несколько секунд."
     errors:
-      invalid_seats: "Введите количество мест больше нуля."
+      invalid_entries: "Введите количество регистраций больше нуля."

--- a/db/migrate/20260504182323_rename_event_seat_payments_to_event_entry_payments.rb
+++ b/db/migrate/20260504182323_rename_event_seat_payments_to_event_entry_payments.rb
@@ -1,0 +1,13 @@
+class RenameEventSeatPaymentsToEventEntryPayments < ActiveRecord::Migration[8.0]
+  def change
+    rename_table :event_seat_payments, :event_entry_payments
+    rename_column :event_entry_payments, :seats, :entries
+
+    rename_index :event_entry_payments,
+                 'index_event_seat_payments_on_payable',
+                 'index_event_entry_payments_on_payable'
+    rename_index :event_entry_payments,
+                 'index_event_seat_payments_unique_purchase',
+                 'index_event_entry_payments_unique_purchase'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_04_122251) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_04_182323) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "unaccent"
@@ -71,6 +71,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_122251) do
     t.index ["team_id"], name: "index_event_competitors_on_team_id"
   end
 
+  create_table "event_entry_payments", force: :cascade do |t|
+    t.integer "amount_cents", null: false
+    t.datetime "created_at", null: false
+    t.integer "entries", null: false
+    t.string "kind", null: false
+    t.bigint "pay_charge_id", null: false
+    t.bigint "payable_id", null: false
+    t.string "payable_type", null: false
+    t.string "stripe_refund_id"
+    t.datetime "updated_at", null: false
+    t.index ["pay_charge_id", "kind"], name: "index_event_entry_payments_unique_purchase", unique: true, where: "((kind)::text = 'purchase'::text)"
+    t.index ["pay_charge_id"], name: "index_event_entry_payments_on_pay_charge_id"
+    t.index ["payable_type", "payable_id"], name: "index_event_entry_payments_on_payable"
+    t.index ["stripe_refund_id"], name: "index_event_entry_payments_on_stripe_refund_id", unique: true, where: "(stripe_refund_id IS NOT NULL)"
+  end
+
   create_table "event_reference_point_assignments", force: :cascade do |t|
     t.bigint "competitor_id"
     t.datetime "created_at", precision: nil, null: false
@@ -123,22 +139,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_122251) do
     t.integer "profile_id"
     t.timestamptz "updated_at"
     t.index ["event_id"], name: "index_event_rounds_on_event_id"
-  end
-
-  create_table "event_seat_payments", force: :cascade do |t|
-    t.integer "amount_cents", null: false
-    t.datetime "created_at", null: false
-    t.string "kind", null: false
-    t.bigint "pay_charge_id", null: false
-    t.bigint "payable_id", null: false
-    t.string "payable_type", null: false
-    t.integer "seats", null: false
-    t.string "stripe_refund_id"
-    t.datetime "updated_at", null: false
-    t.index ["pay_charge_id", "kind"], name: "index_event_seat_payments_unique_purchase", unique: true, where: "((kind)::text = 'purchase'::text)"
-    t.index ["pay_charge_id"], name: "index_event_seat_payments_on_pay_charge_id"
-    t.index ["payable_type", "payable_id"], name: "index_event_seat_payments_on_payable"
-    t.index ["stripe_refund_id"], name: "index_event_seat_payments_on_stripe_refund_id", unique: true, where: "(stripe_refund_id IS NOT NULL)"
   end
 
   create_table "event_sections", id: :serial, force: :cascade do |t|
@@ -889,8 +889,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_122251) do
   add_foreign_key "contribution_details", "profiles"
   add_foreign_key "event_competitors", "event_teams", column: "team_id"
   add_foreign_key "event_competitors", "profiles"
+  add_foreign_key "event_entry_payments", "pay_charges"
   add_foreign_key "event_results", "tracks"
-  add_foreign_key "event_seat_payments", "pay_charges"
   add_foreign_key "event_teams", "countries"
   add_foreign_key "free_pro_views", "tracks"
   add_foreign_key "free_pro_views", "users"

--- a/test/controllers/payments_controller_test.rb
+++ b/test/controllers/payments_controller_test.rb
@@ -31,9 +31,9 @@ class PaymentsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test 'create rejects zero or negative seats' do
+  test 'create rejects zero or negative entries' do
     sign_in @organizer
-    post speed_skydiving_competition_payments_path(@event), params: { seats: 0 }
+    post speed_skydiving_competition_payments_path(@event), params: { entries: 0 }
     assert_redirected_to speed_skydiving_competition_payments_path(@event)
     follow_redirect!
     assert_match(/greater than zero/i, flash[:alert] || @response.body)

--- a/test/models/event_entry_payment_test.rb
+++ b/test/models/event_entry_payment_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class EventSeatPaymentTest < ActiveSupport::TestCase
+class EventEntryPaymentTest < ActiveSupport::TestCase
   setup do
     @event = speed_skydiving_competitions(:nationals)
     @user = users(:regular_user)
@@ -24,21 +24,21 @@ class EventSeatPaymentTest < ActiveSupport::TestCase
   end
 
   test 'reconciler creates a purchase row for a paid charge' do
-    assert_difference -> { EventSeatPayment.count } => 1 do
+    assert_difference -> { EventEntryPayment.count } => 1 do
       build_charge(
         metadata: {
-          'type' => 'event_seats',
+          'type' => 'event_entries',
           'event_type' => 'SpeedSkydivingCompetition',
           'event_id' => @event.id,
-          'seats' => 3
+          'entries' => 3
         },
         amount: 4500
       )
     end
 
-    payment = EventSeatPayment.last
+    payment = EventEntryPayment.last
     assert_equal 'purchase', payment.kind
-    assert_equal 3, payment.seats
+    assert_equal 3, payment.entries
     assert_equal 4500, payment.amount_cents
     assert_equal @event, payment.payable
   end
@@ -46,46 +46,46 @@ class EventSeatPaymentTest < ActiveSupport::TestCase
   test 'reconciler is idempotent on repeated saves' do
     charge = build_charge(
       metadata: {
-        'type' => 'event_seats',
+        'type' => 'event_entries',
         'event_type' => 'SpeedSkydivingCompetition',
         'event_id' => @event.id,
-        'seats' => 2
+        'entries' => 2
       },
       amount: 3000
     )
 
-    assert_no_difference -> { EventSeatPayment.where(kind: 'purchase').count } do
+    assert_no_difference -> { EventEntryPayment.where(kind: 'purchase').count } do
       charge.update!(amount_refunded: 0)
       charge.touch
     end
   end
 
-  test 'reconciler ignores non-event_seats charges' do
-    assert_no_difference -> { EventSeatPayment.count } do
+  test 'reconciler ignores non-event_entries charges' do
+    assert_no_difference -> { EventEntryPayment.count } do
       build_charge(metadata: { 'type' => 'lifetime' }, amount: 5900)
     end
   end
 
-  test 'reconciler records refund as negative seats' do
+  test 'reconciler records refund as negative entries' do
     refund = { 'id' => 're_test_123', 'amount' => 1500 }
     charge = build_charge(
       metadata: {
-        'type' => 'event_seats',
+        'type' => 'event_entries',
         'event_type' => 'SpeedSkydivingCompetition',
         'event_id' => @event.id,
-        'seats' => 3
+        'entries' => 3
       },
       amount: 4500
     )
 
-    assert_difference -> { EventSeatPayment.where(kind: 'refund').count } => 1 do
+    assert_difference -> { EventEntryPayment.where(kind: 'refund').count } => 1 do
       charge.data = { 'refunds' => { 'data' => [refund] } }
       charge.amount_refunded = 1500
       charge.save!
     end
 
-    refund_row = EventSeatPayment.find_by(stripe_refund_id: 're_test_123')
-    assert_equal(-1, refund_row.seats)
+    refund_row = EventEntryPayment.find_by(stripe_refund_id: 're_test_123')
+    assert_equal(-1, refund_row.entries)
     assert_equal(-1500, refund_row.amount_cents)
   end
 
@@ -93,33 +93,33 @@ class EventSeatPaymentTest < ActiveSupport::TestCase
     refund = { 'id' => 're_test_999', 'amount' => 1500 }
     charge = build_charge(
       metadata: {
-        'type' => 'event_seats',
+        'type' => 'event_entries',
         'event_type' => 'SpeedSkydivingCompetition',
         'event_id' => @event.id,
-        'seats' => 3
+        'entries' => 3
       },
       amount: 4500,
       refunds: [refund]
     )
 
-    assert_no_difference -> { EventSeatPayment.where(kind: 'refund').count } do
+    assert_no_difference -> { EventEntryPayment.where(kind: 'refund').count } do
       charge.touch
       charge.save!
     end
   end
 
-  test 'paid_seats sums purchases and refunds' do
+  test 'paid_entries sums purchases and refunds' do
     build_charge(
       metadata: {
-        'type' => 'event_seats',
+        'type' => 'event_entries',
         'event_type' => 'SpeedSkydivingCompetition',
         'event_id' => @event.id,
-        'seats' => 5
+        'entries' => 5
       },
       amount: 7500,
       refunds: [{ 'id' => 're_x', 'amount' => 3000 }]
     )
 
-    assert_equal 3, @event.paid_seats
+    assert_equal 3, @event.paid_entries
   end
 end


### PR DESCRIPTION
## Summary

"Seats" was borrowed from SaaS billing/theatre seating and reads awkwardly when organizers are paying per competitor. "Entries" is the standard term in sports competitions and translates cleanly across all six locales:

| | EN | RU | DE | IT | ES | FR |
|--|--|--|--|--|--|--|
| was | seats | места | Plätze | posti | plazas | places |
| now | entries | регистрации | Anmeldungen | iscrizioni | inscripciones | inscriptions |

## Renames

- table `event_seat_payments` → `event_entry_payments`
- column `seats` → `entries`
- model `EventSeatPayment` → `EventEntryPayment` (+ `Reconciler`)
- concern method `paid_seats` → `paid_entries`
- concern method `seats_underpaid?` → `entries_underpaid?`
- constant `SEAT_PRICE_CENTS` → `ENTRY_PRICE_CENTS`
- charge metadata `type: 'event_seats'` → `'event_entries'`
- form/controller param `seats` → `entries`
- all 6 locale files

The migration is a true rename (`rename_table` + `rename_column` + `rename_index`) so production data is preserved.

## Bonus

Also updates the new-event landing notice (`app/views/events/new.html.erb`):
- Drops the obsolete PayPal link.
- Tells organizers payment is available on the **Payments** tab once the competition is created.
- Bumps support email to `aleksandr@skyderby.io`.

## Test plan

- [ ] Migration runs cleanly and renames table/column/indexes
- [ ] Existing `EventSeatPayment` rows (if any) are accessible as `EventEntryPayment` after deploy
- [ ] Payments page renders with new copy in each locale
- [ ] New Stripe Checkout session uses `type: 'event_entries'` metadata; webhook reconciles into the renamed table
- [ ] `/events/new` no longer shows PayPal link

⚠️ **Stripe metadata note**: any in-flight Checkout sessions created before this PR was deployed carry `type: 'event_seats'` metadata; they will not auto-reconcile post-deploy. None expected (feature only just launched), but worth flagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)