### PR TITLE
Add missing redis gem for Action Cable pubsub adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,8 @@ gem 'shrine', '~> 3.0'
 # XML
 gem 'nokogiri', '~> 1.16'
 
-# Background jobs
+# Background jobs & cache
+gem 'redis'
 gem 'sidekiq'
 gem 'sidekiq-cron'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -415,6 +415,8 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
+    redis (5.4.1)
+      redis-client (>= 0.22.0)
     redis-client (0.26.3)
       connection_pool
     regexp_parser (2.11.3)
@@ -617,6 +619,7 @@ DEPENDENCIES
   pundit
   rack-cors
   rails (~> 8.1.0)
+  redis
   rubocop
   rubocop-minitest
   rubocop-performance


### PR DESCRIPTION
## Summary

- Add `redis` gem to `Gemfile` — it was missing despite Action Cable being configured to use the Redis pubsub adapter (`config/cable.yml`), causing a `Gem::LoadError` at boot

## Test plan

- [ ] Boot the app and confirm no `Gem::LoadError` for `redis`
- [ ] Verify Action Cable connections work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)