### PR TITLE
Improve Skydive Pro View comparison and access

### DIFF
--- a/app/assets/stylesheets/tracks/_skydive_performance.css
+++ b/app/assets/stylesheets/tracks/_skydive_performance.css
@@ -68,6 +68,20 @@
   display: block;
 }
 
+.skydive-performance-empty-state {
+  position: absolute;
+  inset: 0;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  text-align: center;
+  color: var(--gray-60);
+}
+
+.skydive-performance-empty-state:not(.hidden) {
+  display: flex;
+}
+
 .skydive-performance-chart .grid-line {
   stroke: #e0e0e0;
   stroke-width: 1;
@@ -117,6 +131,10 @@
   fill: var(--blue-80);
 }
 
+.skydive-performance-chart .wind-indicator-pilot--compare {
+  fill: #9C27B0;
+}
+
 .skydive-performance-chart .wind-indicator-sector {
   stroke: var(--gray-60);
   stroke-width: 1;
@@ -156,7 +174,7 @@
 
 .skydive-performance-chart .track-path--compare {
   fill: none;
-  stroke: var(--gray-50);
+  stroke: #9C27B0;
   stroke-width: 2;
   stroke-linecap: round;
   stroke-linejoin: round;
@@ -361,68 +379,42 @@
   border-bottom: 1px solid var(--gray-30);
 }
 
+.skydive-performance-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+
 .comparison-actions {
   display: flex;
   justify-content: flex-end;
-  margin-top: 0.5rem;
 }
 
-.comparison-search {
-  margin-bottom: 1rem;
-}
-
-.comparison-results {
-  max-height: 400px;
-  overflow-y: auto;
-}
-
-.comparison-results-placeholder {
-  text-align: center;
-  color: var(--gray-60);
-  padding: 2rem;
-}
-
-.comparison-result-item {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem;
-  border-radius: 4px;
-  cursor: pointer;
-  transition: background-color 0.15s;
-}
-
-.comparison-result-item:hover {
-  background: var(--gray-10);
-}
-
-.comparison-result-item-photo {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 50%;
-  object-fit: cover;
-}
-
-.comparison-result-item-info {
-  flex: 1;
-  min-width: 0;
-}
-
-.comparison-result-item-name {
-  font-weight: 500;
-  color: var(--gray-90);
-}
-
-.comparison-result-item-details {
-  font-size: 0.875rem;
-  color: var(--gray-60);
+.dialog:has(.comparison-explorer) {
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
-.comparison-loading {
+.dialog-body.comparison-explorer {
   display: flex;
-  justify-content: center;
-  padding: 2rem;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  padding: 0;
+}
+
+.comparison-explorer-search {
+  position: relative;
+  z-index: 1;
+  padding: 1rem;
+  background-color: var(--white);
+  box-shadow: 0 0.25rem 0.5rem -0.25rem rgba(0, 0, 0, 0.15);
+}
+
+.comparison-explorer-list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0.25rem 1rem 1rem;
 }

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -132,6 +132,7 @@ class TracksController < ApplicationController
       :place_id,
       :year,
       :infinite,
+      :exclude_id,
       profile_id: [],
       suit_id: [],
       place_id: [],

--- a/app/javascript/charts/glideRatio.js
+++ b/app/javascript/charts/glideRatio.js
@@ -60,7 +60,7 @@ export const compareGlideRatioSeries = (
   name: name || 'Comparison',
   custom: { code: 'gr_compare' },
   type: 'spline',
-  color: '#9e9e9e',
+  color: '#37889B',
   dashStyle: 'ShortDash',
   data: points.map(point => {
     const relativeTime = point.flTime - points[0].flTime

--- a/app/javascript/charts/speed.js
+++ b/app/javascript/charts/speed.js
@@ -93,7 +93,7 @@ export const compareHorizontalSpeedSeries = (
   name: name ? `${name} H` : 'Comparison H',
   custom: { code: 'compare_ground_speed' },
   type: 'spline',
-  color: '#9e9e9e',
+  color: '#52A964',
   dashStyle: 'ShortDash',
   data: points.map(point => {
     const relativeTime = point.flTime - points[0].flTime
@@ -121,7 +121,7 @@ export const compareVerticalSpeedSeries = (
   name: name ? `${name} V` : 'Comparison V',
   custom: { code: 'compare_vertical_speed' },
   type: 'spline',
-  color: '#bdbdbd',
+  color: '#A7414E',
   dashStyle: 'ShortDash',
   data: points.map(point => {
     const relativeTime = point.flTime - points[0].flTime
@@ -133,6 +133,35 @@ export const compareVerticalSpeedSeries = (
         altitude: Math.round(point.altitude),
         gpsTime: point.gpsTime,
         tooltipValue: `${Math.round(point.vSpeed)} ${I18n.t('units.kmh')}`
+      }
+    }
+  }),
+  ...options
+})
+
+export const compareFullSpeedSeries = (
+  points,
+  primaryPoints,
+  timeOffset,
+  name,
+  options
+) => ({
+  name: name ? `${name} Full` : 'Comparison Full',
+  custom: { code: 'compare_full_speed' },
+  type: 'spline',
+  color: '#D6A184',
+  dashStyle: 'ShortDash',
+  visible: false,
+  data: points.map(point => {
+    const relativeTime = point.flTime - points[0].flTime
+    const adjustedTime = relativeTime + timeOffset
+    return {
+      x: adjustedTime,
+      y: Math.round(point.fullSpeed),
+      custom: {
+        altitude: Math.round(point.altitude),
+        gpsTime: point.gpsTime,
+        tooltipValue: `${Math.round(point.fullSpeed)} ${I18n.t('units.kmh')}`
       }
     }
   }),
@@ -238,7 +267,10 @@ export const initSpeedsChart = (
           points,
           compareTimeOffset,
           compareTrackName
-        )
+        ),
+      comparePoints &&
+        comparePoints.length > 0 &&
+        compareFullSpeedSeries(comparePoints, points, compareTimeOffset, compareTrackName)
     ].filter(Boolean)
   }
 

--- a/app/javascript/controllers/omni_search_controller.js
+++ b/app/javascript/controllers/omni_search_controller.js
@@ -1,6 +1,8 @@
 import { Controller } from '@hotwired/stimulus'
 import debounce from 'lodash.debounce'
 
+let anchorCounter = 0
+
 export default class OmniSearchController extends Controller {
   static targets = ['model', 'typeSelect', 'tagsContainer', 'tagTemplate', 'dropdown']
 
@@ -10,6 +12,10 @@ export default class OmniSearchController extends Controller {
     this.onToggle = this.onToggle.bind(this)
     this.onClick = this.onClick.bind(this)
     this.search = debounce(this.search.bind(this), 300)
+
+    const anchorName = `--omni-search-${(anchorCounter += 1)}`
+    this.element.style.setProperty('anchor-name', anchorName)
+    this.dropdownTarget.style.setProperty('position-anchor', anchorName)
 
     this.focusedOptionIndex = -1
     this.currentView = null

--- a/app/javascript/controllers/tracks/skydive_performance_track_controller.js
+++ b/app/javascript/controllers/tracks/skydive_performance_track_controller.js
@@ -11,7 +11,6 @@ import { createDesignatedLane } from 'utils/laneValidation/designatedLane'
 import { interpolatePointByTime } from 'utils/laneValidation/utils'
 import { detectFlares, drawFlares } from 'utils/tracks/flareDetection'
 import { computeBestWindows } from 'utils/tracks/bestWindows'
-import debounce from 'lodash.debounce'
 
 const CHART_PADDING = { left: 100, right: 20, top: 10, bottom: 45 }
 
@@ -67,10 +66,9 @@ export default class extends Controller {
     'windEffectGlideRatioWind',
     'designatedLaneToggle',
     'straightLineToggle',
+    'emptyState',
     'sepChart',
     'compareModal',
-    'compareSearchInput',
-    'compareResults',
     'compareMap',
     'compareDistance',
     'compareGroundSpeed',
@@ -109,9 +107,9 @@ export default class extends Controller {
     weatherUrl: String,
     referencePointUrl: String,
     comparePointsUrl: String,
+    compareWeatherUrl: String,
     compareTrackName: String,
-    trackId: Number,
-    searchUrl: String
+    trackId: Number
   }
 
   connect() {
@@ -119,7 +117,6 @@ export default class extends Controller {
     this.currentIndex = 0
     this.referencePointData = null
     this.comparePoints = null
-    this.searchCompareTracks = debounce(this.searchCompareTracks.bind(this), 300)
     this.initializeStraightLine()
 
     const fetches = [
@@ -131,22 +128,50 @@ export default class extends Controller {
 
     if (this.hasComparePointsUrlValue) {
       fetches.push(this.fetchComparePoints())
+      fetches.push(this.fetchCompareWeather())
     }
 
-    Promise.all(fetches).then(
-      ([pointsData, weatherData, referencePointData, _, compareData]) => {
-        this.points = pointsData.points
-        this.weatherData = weatherData
-        this.referencePointData = referencePointData
-        if (compareData) {
-          this.comparePoints = compareData.points
+    Promise.all(fetches)
+      .then(
+        ([
+          pointsData,
+          weatherData,
+          referencePointData,
+          _,
+          compareData,
+          compareWeatherData
+        ]) => {
+          this.points = pointsData.points
+          this.weatherData = weatherData
+          this.referencePointData = referencePointData
+          if (compareData) {
+            this.comparePoints = compareData.points
+          }
+          if (compareWeatherData) {
+            this.compareWeatherData = compareWeatherData
+          }
+
+          if (!this.points || this.points.length === 0) {
+            this.showEmptyState()
+            return
+          }
+
+          this.initializeRange()
+          this.updateView()
+          this.initDesignatedLane()
+          this.computeBestWindows()
         }
-        this.initializeRange()
-        this.updateView()
-        this.initDesignatedLane()
-        this.computeBestWindows()
-      }
-    )
+      )
+      .catch(error => {
+        console.error('Failed to initialize skydive performance view', error)
+        this.showEmptyState()
+      })
+  }
+
+  showEmptyState() {
+    if (this.hasEmptyStateTarget) {
+      this.emptyStateTarget.classList.remove('hidden')
+    }
   }
 
   computeBestWindows() {
@@ -271,6 +296,19 @@ export default class extends Controller {
       .catch(() => [])
   }
 
+  fetchCompareWeather() {
+    if (!this.hasCompareWeatherUrlValue) return Promise.resolve([])
+
+    return fetch(this.compareWeatherUrlValue, {
+      headers: { Accept: 'application/json' }
+    })
+      .then(response => {
+        if (!response.ok) return []
+        return response.json()
+      })
+      .catch(() => [])
+  }
+
   fetchReferencePoint() {
     if (!this.hasReferencePointUrlValue) return Promise.resolve(null)
 
@@ -304,6 +342,17 @@ export default class extends Controller {
 
   get hasWeatherData() {
     return this.weatherData && this.weatherData.length > 0
+  }
+
+  get hasCompareWeatherData() {
+    return this.compareWeatherData && this.compareWeatherData.length > 0
+  }
+
+  get compareWeather() {
+    if (!this._compareWeather && this.hasCompareWeatherData) {
+      this._compareWeather = new WeatherData(this.compareWeatherData)
+    }
+    return this._compareWeather
   }
 
   initializeRange() {
@@ -519,6 +568,41 @@ export default class extends Controller {
     })
   }
 
+  buildCompareProcessedPoints(primaryEntryDistance) {
+    const primaryStartTime = this.chartPoints[0].gpsTime.getTime()
+
+    let distance = 0
+    const points = this.comparePoints.map((point, index) => {
+      if (index > 0) {
+        distance += this.calculateDistance(point, this.comparePoints[index - 1])
+      }
+      const srcGpsTime = point.gpsTime.getTime()
+      const gpsTime = srcGpsTime + this.compareTimeOffset
+
+      return {
+        playerTime: (gpsTime - primaryStartTime) / 1000,
+        altitude: point.altitude,
+        distance,
+        latitude: point.latitude,
+        longitude: point.longitude,
+        hSpeed: point.hSpeed,
+        vSpeed: point.vSpeed,
+        fullSpeed: point.fullSpeed,
+        glideRatio: point.glideRatio,
+        gpsTime,
+        srcGpsTime
+      }
+    })
+
+    const compareEntryDistance = this.findDistanceAtWindowEntry(points, this.fromValue)
+    const distanceOffset = primaryEntryDistance - compareEntryDistance
+    points.forEach(point => {
+      point.distance += distanceOffset
+    })
+
+    return points
+  }
+
   calculateDistance(point, startPoint) {
     const R = 6371000
     const lat1 = (startPoint.latitude * Math.PI) / 180
@@ -621,48 +705,7 @@ export default class extends Controller {
       this.fromValue
     )
 
-    let compareCumulative = 0
-    const compareDistances = compareChartPoints.map((point, idx) => {
-      if (idx > 0) {
-        compareCumulative += this.calculateDistance(point, compareChartPoints[idx - 1])
-      }
-      return compareCumulative
-    })
-
-    const compareEntryIndexInfo = this.findWindowEntryIndex(
-      compareChartPoints,
-      this.fromValue
-    )
-    let compareEntryDistance = 0
-    if (compareEntryIndexInfo) {
-      const { index, fraction } = compareEntryIndexInfo
-      const d1 = compareDistances[index]
-      const d2 = compareDistances[Math.min(index + 1, compareDistances.length - 1)]
-      compareEntryDistance = d1 + (d2 - d1) * fraction
-    }
-
-    const distanceOffset = primaryEntryDistance - compareEntryDistance
-
-    const primaryStartTime = this.chartPoints[0].gpsTime.getTime()
-
-    this.compareProcessedPoints = compareChartPoints.map((point, idx) => {
-      const adjustedGpsTime = point.gpsTime.getTime() + this.compareTimeOffset
-      const playerTime = (adjustedGpsTime - primaryStartTime) / 1000
-      const distance = compareDistances[idx] + distanceOffset
-
-      return {
-        playerTime,
-        altitude: point.altitude,
-        distance,
-        latitude: point.latitude,
-        longitude: point.longitude,
-        hSpeed: point.hSpeed,
-        vSpeed: point.vSpeed,
-        fullSpeed: point.fullSpeed,
-        glideRatio: point.glideRatio,
-        gpsTime: adjustedGpsTime
-      }
-    })
+    this.compareProcessedPoints = this.buildCompareProcessedPoints(primaryEntryDistance)
 
     let compareWindowPoints = cropPoints(this.comparePoints, this.fromValue, this.toValue)
     if (compareWindowPoints.length > 0) {
@@ -758,14 +801,39 @@ export default class extends Controller {
     if (!this.hasWeatherData || this.processedPoints.length === 0) return
 
     const { width } = this.chartDimensions
-    const ns = 'http://www.w3.org/2000/svg'
-    const fontSize = this.viewBoxFontSize(12)
     const radius = 42
     const margin = 10
-
     const cx = width - margin - radius
-    const cy = margin + radius
-    this.windIndicatorCenter = { cx, cy, radius }
+
+    this.windIndicators = []
+
+    this.windIndicators.push(
+      this.buildWindIndicator(cx, margin + radius, radius, 'wind-indicator-pilot', {
+        points: this.processedPoints,
+        weather: this.weather,
+        referenceTime: this.processedPoints[0].gpsTime
+      })
+    )
+
+    if (this.hasCompareWeatherData && this.compareProcessedPoints?.length) {
+      const fontSize = this.viewBoxFontSize(12)
+      const secondCy = margin + radius + (radius * 2 + margin + fontSize * 1.4)
+      this.windIndicators.push(
+        this.buildWindIndicator(cx, secondCy, radius, 'wind-indicator-pilot--compare', {
+          points: this.compareProcessedPoints,
+          weather: this.compareWeather,
+          referenceTime: this.comparePoints[0].gpsTime,
+          byPlayerTime: true
+        })
+      )
+    }
+
+    this.updateWindIndicators(this.currentIndex || 0)
+  }
+
+  buildWindIndicator(cx, cy, radius, pilotClass, source) {
+    const ns = 'http://www.w3.org/2000/svg'
+    const fontSize = this.viewBoxFontSize(12)
 
     const group = document.createElementNS(ns, 'g')
     group.setAttribute('class', 'wind-indicator')
@@ -795,58 +863,77 @@ export default class extends Controller {
     const scale = iconSize / 640
     const pilot = document.createElementNS(ns, 'path')
     pilot.setAttribute('d', LOCATION_ARROW_PATH)
-    pilot.setAttribute('class', 'wind-indicator-pilot')
+    pilot.setAttribute('class', pilotClass)
     pilot.setAttribute(
       'transform',
       `translate(${cx} ${cy}) rotate(45) scale(${scale}) translate(-320 -320)`
     )
     group.appendChild(pilot)
 
-    this.windArrow = document.createElementNS(ns, 'path')
-    this.windArrow.setAttribute('d', 'M -10 -7 L 5 0 L -10 7 Z')
-    this.windArrow.setAttribute('class', 'wind-indicator-arrow')
-    group.appendChild(this.windArrow)
+    const arrow = document.createElementNS(ns, 'path')
+    arrow.setAttribute('d', 'M -10 -7 L 5 0 L -10 7 Z')
+    arrow.setAttribute('class', 'wind-indicator-arrow')
+    group.appendChild(arrow)
 
-    const makeLabel = (x, y, rotation, baseline) => {
+    const makeLabel = (x, y) => {
       const text = document.createElementNS(ns, 'text')
       text.setAttribute('x', x)
       text.setAttribute('y', y)
       text.setAttribute('text-anchor', 'middle')
-      text.setAttribute('dominant-baseline', baseline)
+      text.setAttribute('dominant-baseline', 'central')
       text.setAttribute('font-size', fontSize)
       text.setAttribute('class', 'wind-indicator-component')
-      if (rotation) text.setAttribute('transform', `rotate(${rotation} ${x} ${y})`)
       group.appendChild(text)
       return text
     }
 
     const labelRadius = radius * 0.62
-    this.windHeadText = makeLabel(cx + labelRadius, cy, 0, 'central')
-    this.windTailText = makeLabel(cx - labelRadius, cy, 0, 'central')
-    this.windLeftText = makeLabel(cx, cy - labelRadius, 0, 'central')
-    this.windRightText = makeLabel(cx, cy + labelRadius, 0, 'central')
-
-    this.windTotalText = makeLabel(cx, cy + radius + fontSize * 0.55, 0, 'central')
-    this.windTotalText.classList.add('wind-indicator-total')
+    const headText = makeLabel(cx + labelRadius, cy)
+    const tailText = makeLabel(cx - labelRadius, cy)
+    const leftText = makeLabel(cx, cy - labelRadius)
+    const rightText = makeLabel(cx, cy + labelRadius)
+    const totalText = makeLabel(cx, cy + radius + fontSize * 0.55)
+    totalText.classList.add('wind-indicator-total')
 
     this.trajectoryTarget.appendChild(group)
 
-    this.updateWindIndicator(this.currentIndex || 0)
+    return {
+      center: { cx, cy, radius },
+      arrow,
+      headText,
+      tailText,
+      leftText,
+      rightText,
+      totalText,
+      ...source
+    }
   }
 
-  updateWindIndicator(index) {
-    if (!this.windArrow || !this.windIndicatorCenter || !this.weather) return
+  updateWindIndicators(index) {
+    if (!this.windIndicators) return
 
-    const point = this.processedPoints[index]
+    this.windIndicators.forEach(indicator => {
+      let pointIndex = index
+      if (indicator.byPlayerTime) {
+        const playerTime = this.processedPoints[index]?.playerTime
+        if (playerTime === undefined) return
+        pointIndex = this.closestIndexByPlayerTime(indicator.points, playerTime)
+      }
+      this.updateWindIndicator(indicator, pointIndex)
+    })
+  }
+
+  updateWindIndicator(indicator, index) {
+    const { points, weather, referenceTime } = indicator
+    if (!weather) return
+
+    const point = points[index]
     if (!point) return
 
-    const targetIndex = this.findTargetIndexFrom(index)
-    const heading = this.calculateBearing(point, this.processedPoints[targetIndex])
+    const targetIndex = this.targetIndexFrom(points, index)
+    const heading = this.calculateBearing(point, points[targetIndex])
 
-    const { windSpeed, windDirection } = this.weather.weatherOn(
-      this.processedPoints[0].gpsTime,
-      point.altitude
-    )
+    const { windSpeed, windDirection } = weather.weatherOn(referenceTime, point.altitude)
 
     const relativeFrom = (((windDirection - heading) % 360) + 360) % 360
     const angle = (relativeFrom * Math.PI) / 180
@@ -854,23 +941,53 @@ export default class extends Controller {
     const dx = Math.cos(angle)
     const dy = Math.sin(angle)
 
-    const { cx, cy, radius } = this.windIndicatorCenter
+    const { cx, cy, radius } = indicator.center
     const px = cx + radius * dx
     const py = cy + radius * dy
     const rotation = (Math.atan2(-dy, -dx) * 180) / Math.PI
 
-    this.windArrow.setAttribute('transform', `translate(${px} ${py}) rotate(${rotation})`)
+    indicator.arrow.setAttribute(
+      'transform',
+      `translate(${px} ${py}) rotate(${rotation})`
+    )
 
     const speedKmh = windSpeed * 3.6
     const head = Math.round(speedKmh * Math.cos(angle))
     const side = Math.round(speedKmh * Math.sin(angle))
     const total = Math.round(speedKmh)
 
-    this.windHeadText.textContent = head > 0 ? `${head}` : ''
-    this.windTailText.textContent = head < 0 ? `${-head}` : ''
-    this.windLeftText.textContent = side < 0 ? `${-side}` : ''
-    this.windRightText.textContent = side > 0 ? `${side}` : ''
-    this.windTotalText.textContent = total > 0 ? `${total} km/h` : ''
+    indicator.headText.textContent = head > 0 ? `${head}` : ''
+    indicator.tailText.textContent = head < 0 ? `${-head}` : ''
+    indicator.leftText.textContent = side < 0 ? `${-side}` : ''
+    indicator.rightText.textContent = side > 0 ? `${side}` : ''
+    indicator.totalText.textContent = total > 0 ? `${total} km/h` : ''
+  }
+
+  closestIndexByPlayerTime(points, playerTime) {
+    let closestIndex = 0
+    let minDiff = Infinity
+
+    points.forEach((point, index) => {
+      const diff = Math.abs(point.playerTime - playerTime)
+      if (diff < minDiff) {
+        minDiff = diff
+        closestIndex = index
+      }
+    })
+
+    return closestIndex
+  }
+
+  targetIndexFrom(points, fromIndex) {
+    const targetTime = points[fromIndex].gpsTime + 3000
+
+    for (let i = fromIndex + 1; i < points.length; i++) {
+      if (points[i].gpsTime >= targetTime) {
+        return i
+      }
+    }
+
+    return points.length - 1
   }
 
   renderMaxSpeedMarker() {
@@ -1461,6 +1578,7 @@ export default class extends Controller {
     this.playbackSliderTarget.value = 0
     this.currentIndex = 0
     this.createMapMarker()
+    this.createCompareMapMarker()
     this.createCrosshair()
   }
 
@@ -1486,6 +1604,34 @@ export default class extends Controller {
     })
 
     this.markerElement = img
+  }
+
+  createCompareMapMarker() {
+    if (!this.compareMap || !this.compareProcessedPoints?.length) return
+
+    if (this.compareMapMarker) {
+      this.compareMapMarker.map = null
+    }
+
+    const firstPoint = this.compareProcessedPoints[0]
+
+    const marker = document.createElement('div')
+    marker.style.width = '24px'
+    marker.style.height = '24px'
+    marker.style.transform = 'translateY(50%) rotate(-45deg)'
+    marker.innerHTML =
+      '<svg viewBox="0 0 640 640" width="24" height="24">' +
+      `<path fill="#9C27B0" d="${LOCATION_ARROW_PATH}"/></svg>`
+
+    this.compareMapMarker = new google.maps.marker.AdvancedMarkerElement({
+      map: this.compareMap,
+      position: { lat: firstPoint.latitude, lng: firstPoint.longitude },
+      content: marker
+    })
+
+    this.compareMarkerElement = marker
+
+    this.updateCompareMapMarker(this.processedPoints[0].playerTime)
   }
 
   createCrosshair() {
@@ -1637,7 +1783,7 @@ export default class extends Controller {
     this.updateHighchartsCrosshair(this.currentIndex)
     this.updatePlaybackIndicators(this.currentIndex, 0)
     this.updateMapMarkerAtIndex(this.currentIndex)
-    this.updateWindIndicator(this.currentIndex)
+    this.updateWindIndicators(this.currentIndex)
   }
 
   updatePlaybackPositionInterpolated() {
@@ -1649,7 +1795,7 @@ export default class extends Controller {
     this.updateHighchartsCrosshair(this.currentIndex)
     this.updatePlaybackIndicators(this.currentIndex, this.currentFraction)
     this.updateMapMarkerInterpolated()
-    this.updateWindIndicator(this.currentIndex)
+    this.updateWindIndicators(this.currentIndex)
   }
 
   showCrosshair(index) {
@@ -2063,6 +2209,8 @@ export default class extends Controller {
     const rotation = this.calculateBearing(point, targetPoint)
 
     this.markerElement.style.transform = `translateY(50%) rotate(${rotation - 45}deg)`
+
+    this.updateCompareMapMarker(point.playerTime)
   }
 
   updateMapMarkerInterpolated() {
@@ -2085,19 +2233,35 @@ export default class extends Controller {
     const rotation = this.calculateBearing({ latitude: lat, longitude: lng }, targetPoint)
 
     this.markerElement.style.transform = `translateY(50%) rotate(${rotation - 45}deg)`
+
+    const playerTime = curr.playerTime + (next.playerTime - curr.playerTime) * fraction
+    this.updateCompareMapMarker(playerTime)
+  }
+
+  updateCompareMapMarker(playerTime) {
+    if (
+      !this.compareMapMarker ||
+      !this.compareMarkerElement ||
+      !this.compareProcessedPoints?.length
+    ) {
+      return
+    }
+
+    const index = this.closestIndexByPlayerTime(this.compareProcessedPoints, playerTime)
+    const point = this.compareProcessedPoints[index]
+    if (!point) return
+
+    this.compareMapMarker.position = { lat: point.latitude, lng: point.longitude }
+
+    const targetIndex = this.targetIndexFrom(this.compareProcessedPoints, index)
+    const targetPoint = this.compareProcessedPoints[targetIndex]
+    const rotation = this.calculateBearing(point, targetPoint)
+
+    this.compareMarkerElement.style.transform = `translateY(50%) rotate(${rotation - 45}deg)`
   }
 
   findTargetIndexFrom(fromIndex) {
-    const currentTime = this.processedPoints[fromIndex].gpsTime
-    const targetTime = currentTime + 3000
-
-    for (let i = fromIndex + 1; i < this.processedPoints.length; i++) {
-      if (this.processedPoints[i].gpsTime >= targetTime) {
-        return i
-      }
-    }
-
-    return this.processedPoints.length - 1
+    return this.targetIndexFrom(this.processedPoints, fromIndex)
   }
 
   calculateBearing(from, to) {
@@ -2363,10 +2527,6 @@ export default class extends Controller {
 
     this.compareModalTarget.showModal()
     document.body.classList.add('overflow-hidden')
-
-    if (this.hasCompareSearchInputTarget) {
-      this.compareSearchInputTarget.focus()
-    }
   }
 
   closeCompareModal() {
@@ -2376,83 +2536,15 @@ export default class extends Controller {
     document.body.classList.remove('overflow-hidden')
   }
 
-  searchCompareTracks(event) {
-    const term = event.target.value.trim()
-
-    if (term.length < 2) {
-      this.compareResultsTarget.innerHTML = `
-        <div class="comparison-results-placeholder">
-          Enter at least 2 characters to search
-        </div>
-      `
-      return
-    }
-
-    this.compareResultsTarget.innerHTML = `
-      <div class="comparison-loading">
-        <span>Searching...</span>
-      </div>
-    `
-
-    const url = new URL(this.searchUrlValue, window.location.origin)
-    url.searchParams.set('term', term)
-
-    fetch(url, {
-      headers: { Accept: 'application/json' }
-    })
-      .then(response => response.json())
-      .then(data => {
-        this.renderCompareResults(data)
-      })
-      .catch(() => {
-        this.compareResultsTarget.innerHTML = `
-          <div class="comparison-results-placeholder">
-            Error searching tracks
-          </div>
-        `
-      })
-  }
-
-  renderCompareResults(tracks) {
-    if (!tracks || tracks.length === 0) {
-      this.compareResultsTarget.innerHTML = `
-        <div class="comparison-results-placeholder">
-          No tracks found
-        </div>
-      `
-      return
-    }
-
-    const filteredTracks = tracks.filter(track => track.id !== this.trackIdValue)
-
-    const html = filteredTracks
-      .map(
-        track => `
-        <div class="comparison-result-item"
-             data-action="click->tracks--skydive-performance-track#selectCompareTrack"
-             data-track-id="${track.id}">
-          ${
-            track.pilot?.userpic_url
-              ? `<img src="${track.pilot.userpic_url}" class="comparison-result-item-photo loading-bg" alt="">`
-              : ''
-          }
-          <div class="comparison-result-item-info">
-            <div class="comparison-result-item-name">${track.pilot?.name || track.name || `Track #${track.id}`}</div>
-            <div class="comparison-result-item-details">
-              ${track.suit?.name || ''}
-              ${track.place?.name ? `• ${track.place.name}` : ''}
-            </div>
-          </div>
-        </div>
-      `
-      )
-      .join('')
-
-    this.compareResultsTarget.innerHTML = html
-  }
-
   selectCompareTrack(event) {
-    const trackId = event.currentTarget.dataset.trackId
+    const item = event.target.closest('a.tracks-item')
+    if (!item) return
+
+    event.preventDefault()
+
+    const trackId = item.dataset.id
+    if (!trackId || Number(trackId) === this.trackIdValue) return
+
     const url = new URL(window.location)
     url.searchParams.set('compare_id', trackId)
     window.location.href = url.toString()

--- a/app/javascript/controllers/tracks_search_controller.js
+++ b/app/javascript/controllers/tracks_search_controller.js
@@ -26,7 +26,9 @@ export default class TracksSearchController extends Controller {
 
   handleFilterClear() {
     this.element
-      .querySelectorAll('input:not([name="kind"]):not([name="infinite"])')
+      .querySelectorAll(
+        'input:not([name="kind"]):not([name="infinite"]):not([name="exclude_id"])'
+      )
       .forEach(element => element.remove())
 
     this.submitWithUrlUpdate()
@@ -43,7 +45,7 @@ export default class TracksSearchController extends Controller {
     })
 
     for (const [key, value] of formData.entries()) {
-      if (key === 'kind' || key === 'infinite') continue
+      if (key === 'kind' || key === 'infinite' || key === 'exclude_id') continue
       url.searchParams.append(key, value)
     }
 

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -122,7 +122,6 @@ class Track < ApplicationRecord
   end
 
   def skydive_pro_view_available?(user: Current.user)
-    return false unless user.admin?
     return false unless skydive?
     return false unless user.registered?
 

--- a/app/models/track_filter.rb
+++ b/app/models/track_filter.rb
@@ -7,12 +7,10 @@ class TrackFilter
     return relation unless query
 
     relation = apply_filters_by_relations(relation)
+    relation = apply_scopes(relation)
+    return relation if query[:exclude_id].blank?
 
-    relation = relation.public_send(query[:kind]) if Track.kinds.key? query[:kind]
-    relation = relation.by_year(query[:year]) if query[:year].present?
-    relation = relation.search(query[:term]) if query[:term]
-
-    relation
+    relation.where.not(id: query[:exclude_id])
   end
 
   private
@@ -21,6 +19,14 @@ class TrackFilter
     [:profile_id, :suit_id, :place_id].each do |key|
       relation = relation.where({ key => query[key] }) if query[key].present?
     end
+
+    relation
+  end
+
+  def apply_scopes(relation)
+    relation = relation.public_send(query[:kind]) if Track.kinds.key? query[:kind]
+    relation = relation.by_year(query[:year]) if query[:year].present?
+    relation = relation.search(query[:term]) if query[:term]
 
     relation
   end

--- a/app/views/tracks/_comparison_modal.html.erb
+++ b/app/views/tracks/_comparison_modal.html.erb
@@ -9,20 +9,24 @@
     </button>
   </div>
 
-  <div class="dialog-body">
-    <div class="comparison-search">
-      <input type="text"
-             class="form-control"
-             placeholder="<%= t('tracks.comparison.search_placeholder') %>"
-             data-tracks--skydive-performance-track-target="compareSearchInput"
-             data-action="input->tracks--skydive-performance-track#searchCompareTracks">
-    </div>
+  <div class="dialog-body comparison-explorer">
+    <turbo-frame id="hot-select-search" class="comparison-explorer-search">
+      <%= form_with url: tracks_path, method: :get, data: { controller: 'tracks-search', turbo_frame: 'tracks-list' } do |f| %>
+        <%= f.hidden_field :kind, value: :skydive %>
+        <%= f.hidden_field :infinite, value: true %>
+        <%= f.hidden_field :exclude_id, value: @track.id %>
 
-    <div class="comparison-results"
-         data-tracks--skydive-performance-track-target="compareResults">
-      <div class="comparison-results-placeholder">
-        <%= t('tracks.comparison.search_hint') %>
-      </div>
+        <%= render 'flight_profiles/search_bar', options: [], 'data-action': [
+            'filter:added->tracks-search#handleFilterAdd',
+            'filter:removed->tracks-search#handleFilterRemove',
+            'filter:clear->tracks-search#handleFilterClear',
+          ].join(' ') %>
+      <% end %>
+    </turbo-frame>
+
+    <div class="comparison-explorer-list"
+         data-action="click->tracks--skydive-performance-track#selectCompareTrack">
+      <turbo-frame id="tracks-list" loading="lazy"></turbo-frame>
     </div>
   </div>
 </dialog>

--- a/app/views/tracks/_skydive_performance.html.erb
+++ b/app/views/tracks/_skydive_performance.html.erb
@@ -13,44 +13,46 @@
        data-tracks--skydive-performance-track-reference-point-url-value="<%= track_reference_point_path(@track) %>"
        data-tracks--skydive-performance-track-location-arrow-url-value="<%= asset_path('icons/location-arrow.svg') %>"
        data-tracks--skydive-performance-track-track-id-value="<%= @track.id %>"
-       data-tracks--skydive-performance-track-search-url-value="<%= tracks_path(kind: 'skydive', format: :json) %>"
        <% if @compare_track %>
        data-tracks--skydive-performance-track-compare-points-url-value="<%= track_points_path(@compare_track, original_frequency: true, trimmed: { seconds_before_start: 5, seconds_after_end: 10 }) %>"
+       data-tracks--skydive-performance-track-compare-weather-url-value="<%= track_weather_data_path(@compare_track) %>"
        data-tracks--skydive-performance-track-compare-track-name-value="<%= @compare_track.pilot&.name || @compare_track.name %>"
        <% end %>
        data-tracks--skydive-performance-track-tracks--range-selector-outlet="#range-selector"
        data-action="tracks--range-selector:change->tracks--skydive-performance-track#updateRange">
 
-    <div class="switch-container">
-      <input type="checkbox"
-             id="straight-line-toggle"
-             class="switch-input"
-             data-tracks--skydive-performance-track-target="straightLineToggle"
-             data-action="tracks--skydive-performance-track#toggleStraightLine">
-      <label for="straight-line-toggle" class="switch-label">
-        <span class="switch-slider"></span>
-        <span class="switch-text"><%= t('tracks.show.straight_line_distance') %></span>
-      </label>
+    <div class="skydive-performance-toolbar">
+      <div class="comparison-actions">
+        <% if @compare_track %>
+          <a href="<%= track_path(@track) %>" class="button button--sm button--outline button--danger">
+            <%= t('tracks.comparison.remove') %>
+          </a>
+        <% else %>
+          <button type="button"
+                  class="button button--sm button--outline button--primary"
+                  data-action="tracks--skydive-performance-track#openCompareModal">
+            <%= t('tracks.comparison.compare_button') %>
+          </button>
+        <% end %>
+      </div>
+
+      <div class="switch-container">
+        <input type="checkbox"
+               id="straight-line-toggle"
+               class="switch-input"
+               data-tracks--skydive-performance-track-target="straightLineToggle"
+               data-action="tracks--skydive-performance-track#toggleStraightLine">
+        <label for="straight-line-toggle" class="switch-label">
+          <span class="switch-slider"></span>
+          <span class="switch-text"><%= t('tracks.show.straight_line_distance') %></span>
+        </label>
+      </div>
     </div>
 
     <div class="skydive-performance-indicators-header">
       <%= render 'tracks/skydive_performance_indicators' %>
       <% if @compare_track %>
         <%= render 'tracks/skydive_performance_indicators', compare: true %>
-      <% end %>
-    </div>
-
-    <div class="comparison-actions">
-      <% if @compare_track %>
-        <a href="<%= track_path(@track) %>" class="button button--sm button--ghost">
-          <%= t('tracks.comparison.remove') %>
-        </a>
-      <% else %>
-        <button type="button"
-                class="button button--sm button--ghost hidden"
-                data-action="tracks--skydive-performance-track#openCompareModal">
-          <%= t('tracks.comparison.compare_button') %>
-        </button>
       <% end %>
     </div>
 
@@ -139,6 +141,10 @@
             <g class="chart-grid" data-tracks--skydive-performance-track-target="grid"></g>
             <g class="chart-trajectory" data-tracks--skydive-performance-track-target="trajectory"></g>
           </svg>
+          <div class="skydive-performance-empty-state hidden"
+               data-tracks--skydive-performance-track-target="emptyState">
+            <%= t('tracks.show.no_data') %>
+          </div>
         </div>
       </div>
 

--- a/config/locales/tracks.en.yml
+++ b/config/locales/tracks.en.yml
@@ -16,7 +16,5 @@ en:
       sign_in_prompt: "to try BASE Pro View — 5 free per month"
     comparison:
       modal_title: Compare with another track
-      search_placeholder: Search by pilot name or track ID
-      search_hint: Search for a track to compare
       compare_button: Compare
       remove: Remove comparison

--- a/config/locales/tracks.ru.yml
+++ b/config/locales/tracks.ru.yml
@@ -18,7 +18,5 @@ ru:
       sign_in_prompt: "чтобы попробовать BASE Pro View — 5 треков в месяц бесплатно"
     comparison:
       modal_title: Сравнить с другим треком
-      search_placeholder: Поиск по имени пилота или ID трека
-      search_hint: Найдите трек для сравнения
       compare_button: Сравнить
       remove: Убрать сравнение

--- a/config/locales/views/tracks/de.yml
+++ b/config/locales/views/tracks/de.yml
@@ -36,6 +36,7 @@ de:
       window: Messfenster
       loading: Trackdaten werden geladen
       full_jump: Gesamter Sprung
+      no_data: Keine Trackdaten für diesen Sprung verfügbar
       no_speed_skydiving_result: Für diesen Track konnte kein Speed-Skydiving-Ergebnis berechnet werden
     choose:
       title: 'Track aussuchen zum hochladen'

--- a/config/locales/views/tracks/en.yml
+++ b/config/locales/views/tracks/en.yml
@@ -38,6 +38,7 @@ en:
       window: 'window'
       loading: 'Loading track data'
       full_jump: 'Full jump'
+      no_data: 'No track data available for this jump'
       no_speed_skydiving_result: 'No speed skydiving result could be calculated for this track'
       designated_lane: 'Designated Lane'
       straight_line_distance: 'Straight-line distance'

--- a/config/locales/views/tracks/es.yml
+++ b/config/locales/views/tracks/es.yml
@@ -37,6 +37,7 @@ es:
       window: 'window'
       loading: 'Loading track data'
       full_jump: 'Salto completo'
+      no_data: 'No hay datos de la pista disponibles para este salto'
       no_speed_skydiving_result: 'No se pudo calcular el resultado de speed skydiving para esta pista'
     choose:
       title: 'Elige la pista para descargar'

--- a/config/locales/views/tracks/fr.yml
+++ b/config/locales/views/tracks/fr.yml
@@ -37,6 +37,7 @@ fr:
       window: Fenêtre
       loading: Chargmenet des données de l'enregistrement
       full_jump: Saut complet
+      no_data: Aucune donnée d'enregistrement disponible pour ce saut
       no_speed_skydiving_result: Impossible de calculer le résultat de speed skydiving pour cet enregistrement
     choose:
       title: Sélectionner l'enregistrement à télécharger

--- a/config/locales/views/tracks/it.yml
+++ b/config/locales/views/tracks/it.yml
@@ -37,6 +37,7 @@ it:
       window: 'finestra'
       loading: 'Caricamento dati traccia'
       full_jump: 'Salto completo'
+      no_data: 'Nessun dato della traccia disponibile per questo salto'
       no_speed_skydiving_result: 'Impossibile calcolare il risultato di speed skydiving per questa traccia'
     choose:
       title: 'Seleziona una traccia da caricare'

--- a/config/locales/views/tracks/ru.yml
+++ b/config/locales/views/tracks/ru.yml
@@ -38,6 +38,7 @@ ru:
       window: 'окно'
       loading: 'Загрузка данных трека'
       full_jump: 'Весь прыжок'
+      no_data: 'Нет данных трека для этого прыжка'
       no_speed_skydiving_result: 'Не удалось рассчитать результат скоростного парашютизма для этого трека'
       designated_lane: 'Designated Lane'
       straight_line_distance: 'Расстояние по прямой'


### PR DESCRIPTION
## Summary

Several improvements to the Skydive Pro View, focused on track comparison and access.

### Comparison modal
- Replaced the custom text search with the shared tracks explorer: omni-search filter (Year/Profile/Place/Suit) + lazy `tracks-list` turbo frame, defaulting to the full skydive track list.
- The current track is excluded from the list via a new `exclude_id` filter (`TrackFilter` / tracks index), preserved across filter clears and kept out of the URL.

### Side view & charts (compare mode)
- The compared track is now drawn **fully** on the side view, synced at the window-entry point, in **purple**.
- A second, purple wind indicator is shown under the primary one (the compared track's own weather is fetched).
- Compare chart lines are colored by parameter (dashed); added the compared track's full-speed series.
- Added a synced position marker on the compare map.

### Robustness & access
- Tracks with no points now show a graceful empty state instead of throwing.
- Fixed omni-search dropdown anchoring (per-instance `anchor-name`/`position-anchor`).
- Skydive Pro View is now available to any registered user with an active subscription (removed the admin-only gate).

## Test plan
Verified in local preview:
- Compare modal lists skydive tracks, filter dropdown anchors under the field, current track excluded (also after clearing filters).
- `/tracks/9302?compare_id=9301&f=3000&t=2000` (two tracks with wind): full purple compare path synced at window entry, two wind indicators (second purple), dashed parameter-colored chart lines, compare full-speed series, purple compare map marker tracking playback.
- Single-track view unaffected; empty-points track shows the empty-state message.
- `yarn lint` and `rubocop` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)