### PR TITLE
Align skydive pro elevation/distance chart with siblings

### DIFF
--- a/app/javascript/charts/altitudeDistance.js
+++ b/app/javascript/charts/altitudeDistance.js
@@ -187,7 +187,8 @@ export const initAltitudeDistanceChart = (
           text: ''
         },
         gridLineWidth: 0,
-        opposite: true
+        opposite: true,
+        visible: false
       }
     ],
     tooltip: {


### PR DESCRIPTION
## Problem
On the skydive Pro View, the **Elevation/Distance** chart was slightly out of sync with the other synchronized charts:
- horizontally misaligned plot area
- hovering showed data offset by ~3 seconds

## Cause
The chart had a second, right-side y-axis (`opposite: true`) that reserved horizontal space, making its plot box narrower than the sibling charts. The synchronized hover (`synchronized_charts_controller.js`) maps the same mouse pixel-x onto each chart's plot box, so the narrower box resolved the same pixel to a later point.

## Fix
Set `visible: false` on the right axis — it still scales the Elevation/Distance series but draws nothing and reserves no space.

## Verification (track #1233, Preview)
- All four charts now share the same plot box (`plotLeft:10, plotWidth:743`).
- Pixel x=400 maps to the same time (~45.83s) across all charts; previously the Elevation/Distance chart was ~3s off.
- `yarn lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)