### PR TITLE
Stop double-escaping quotes in page titles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,7 @@
 module ApplicationHelper
   def page_title(title)
     base_title = I18n.t 'static_pages.index.title'
+    title = CGI.unescapeHTML(title.to_s)
     title.present? ? "#{title} - Skyderby" : "Skyderby: #{base_title}"
   end
 

--- a/app/views/layouts/sessions.html.erb
+++ b/app/views/layouts/sessions.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="<%= I18n.locale %>">
   <head>
-    <title><%= content_for?(:title) ? "#{yield(:title)} - SkyDerby" : 'SkyDerby' %></title>
+    <title><%= page_title(yield(:title)) %></title>
     <% if content_for?(:description) %>
       <meta name="description" content="<%= yield(:description) %>">
     <% end %>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class ApplicationHelperTest < ActionView::TestCase
+  test 'page_title keeps quotes in the title readable' do
+    assert_equal %(Wingsuit "Pro" Cup - Skyderby), page_title(ERB::Util.html_escape('Wingsuit "Pro" Cup'))
+  end
+
+  test 'page_title falls back to the base title' do
+    assert_equal "Skyderby: #{I18n.t('static_pages.index.title')}", page_title(nil)
+  end
+end


### PR DESCRIPTION
Competitions whose name contains quotes — e.g. `Wingsuit "Pro" Cup` — rendered as `Wingsuit &quot;Pro&quot; Cup` in the browser tab and in the `og:title` / `twitter:title` meta tags.

`provide :title, @event.name` stores an already-HTML-escaped buffer. `page_title` interpolated that into a plain `String`, which drops the `html_safe` flag, so ERB escaped it a second time (`"` → `&amp;quot;` → displayed as `&quot;`).

- `page_title` now unescapes the incoming title before composing, so the `<%= %>` output does the single, correct escape.
- `layouts/sessions.html.erb` built its title with the same interpolation and had the same latent bug; it now goes through `page_title` too (this also unifies the `SkyDerby` / `Skyderby` casing and the no-title fallback with every other layout).
- Added `test/helpers/application_helper_test.rb`.

Tests and RuboCop pass on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)