### PR TITLE
Add combined scoreboard to online competition groups

### DIFF
--- a/app/assets/stylesheets/_virtual_competition_group.css
+++ b/app/assets/stylesheets/_virtual_competition_group.css
@@ -1,0 +1,40 @@
+.vc-group-scoreboard-table tbody tr.scoreboard-row--striped > td {
+  --pinned-tint: rgba(0, 0, 0, 0.015);
+  background-color: var(--pinned-tint);
+}
+
+.vc-group-scoreboard-table .competitor-profile {
+  font-weight: 700;
+}
+
+.vc-group-scoreboard-table a.result-show-cell,
+.vc-group-scoreboard-table td.scoreboard-total-result {
+  font-weight: 700;
+}
+
+.vc-group-scoreboard-table td.text-green,
+.vc-group-scoreboard-table a.text-green {
+  color: var(--green-90);
+}
+
+.vc-group-scoreboard-table td.result-points-cell {
+  font-variant-numeric: tabular-nums;
+}
+
+.vc-group-scoreboard__more td {
+  text-align: center;
+  padding: 0.5rem;
+}
+
+.vc-group__combined-link {
+  margin-left: 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  text-transform: none;
+}
+
+.vc-group-scoreboard__blank {
+  padding: 2rem;
+  text-align: center;
+  color: var(--gray-70);
+}

--- a/app/controllers/concerns/virtual_competition_group_scoped.rb
+++ b/app/controllers/concerns/virtual_competition_group_scoped.rb
@@ -1,0 +1,27 @@
+module VirtualCompetitionGroupScoped
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :scoreboard_filters
+  end
+
+  private
+
+  def build_scoreboard(group, pages: scoreboard_pages)
+    group.scoreboard(
+      year: params[:year],
+      gender: params[:gender],
+      wind_cancellation: params[:wind].present?,
+      pages:
+    )
+  end
+
+  def scoreboard_pages
+    pages = params.permit(pages: VirtualCompetition::Group::Scoreboard::SUIT_KINDS)[:pages]
+    pages ? pages.to_h : {}
+  end
+
+  def scoreboard_filters
+    params.permit(:year, :gender, :wind).to_h.compact_blank.symbolize_keys
+  end
+end

--- a/app/controllers/virtual_competitions/groups/categories_controller.rb
+++ b/app/controllers/virtual_competitions/groups/categories_controller.rb
@@ -1,0 +1,29 @@
+module VirtualCompetitions
+  module Groups
+    class CategoriesController < ApplicationController
+      include VirtualCompetitionGroupScoped
+
+      def show
+        group = VirtualCompetition::Group.find(params[:virtual_competition_group_id])
+        authorize group, :show?
+
+        suit_kind = params[:suit_kind]
+        @category = build_scoreboard(group, pages: { suit_kind => params[:page] }).category(suit_kind)
+
+        return head :not_found unless @category
+
+        respond_to do |format|
+          format.turbo_stream
+          format.html do
+            redirect_to virtual_competition_group_path(
+              group,
+              **scoreboard_filters,
+              pages: { suit_kind => @category.page },
+              anchor: "group-category-#{suit_kind}"
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/virtual_competitions/groups_controller.rb
+++ b/app/controllers/virtual_competitions/groups_controller.rb
@@ -1,5 +1,7 @@
 module VirtualCompetitions
   class GroupsController < ApplicationController
+    include VirtualCompetitionGroupScoped
+
     before_action :set_group, only: [:show, :edit, :update, :destroy]
 
     def index
@@ -10,6 +12,8 @@ module VirtualCompetitions
 
     def show
       authorize @group
+
+      @scoreboard = build_scoreboard(@group)
     end
 
     def new

--- a/app/helpers/virtual_competitions_helper.rb
+++ b/app/helpers/virtual_competitions_helper.rb
@@ -77,4 +77,18 @@ module VirtualCompetitionsHelper
   def competition_location(competition)
     competition.place_name || t('virtual_competitions.worldwide')
   end
+
+  COMBINED_DISCIPLINE_UNITS = {
+    'distance' => 'm',
+    'speed' => 'kmh',
+    'time' => 't_unit'
+  }.freeze
+
+  def combined_discipline_unit(discipline)
+    t("units.#{COMBINED_DISCIPLINE_UNITS.fetch(discipline)}")
+  end
+
+  def group_category_rows_id(category) = "group-category-#{category.suit_kind}"
+
+  def group_category_more_id(category) = "group-category-#{category.suit_kind}-more"
 end

--- a/app/models/virtual_competition/annual_top_score.rb
+++ b/app/models/virtual_competition/annual_top_score.rb
@@ -33,6 +33,12 @@ class VirtualCompetition::AnnualTopScore < ApplicationRecord
       unscoped.from(ranked_results_sql(snapshot_at: time))
     end
 
+    # The default scope only ever contains raw results, so the wind-cancelled set
+    # needs its own FROM clause rather than a `wind_cancellation(true)` filter.
+    def with_wind_cancellation(wind_cancelled)
+      unscoped.from(ranked_results_sql(wind_cancelled:))
+    end
+
     def ranked_results_sql(snapshot_at: Time.current, wind_cancelled: false)
       best_results_sql = <<~SQL.squish
         SELECT DISTINCT ON (vcr.virtual_competition_id, EXTRACT(YEAR FROM t.recorded_at), t.profile_id)

--- a/app/models/virtual_competition/group.rb
+++ b/app/models/virtual_competition/group.rb
@@ -12,4 +12,14 @@ class VirtualCompetition::Group < ApplicationRecord
   has_many :virtual_competitions, dependent: :restrict_with_error
 
   validates :name, presence: true
+
+  def scoreboard(**) = Scoreboard.new(self, **)
+
+  def years = virtual_competitions.select(&:annual?).flat_map(&:years).uniq.sort
+
+  def combined_scoreboard?
+    virtual_competitions.group_by(&:suits_kind).any? do |suit_kind, competitions|
+      suit_kind.present? && (Scoreboard::DISCIPLINES - competitions.map(&:discipline)).empty?
+    end
+  end
 end

--- a/app/models/virtual_competition/group/scoreboard.rb
+++ b/app/models/virtual_competition/group/scoreboard.rb
@@ -1,0 +1,99 @@
+class VirtualCompetition::Group
+  class Scoreboard
+    DISCIPLINES = %w[distance speed time].freeze
+    SUIT_KINDS = %w[wingsuit monotrack tracksuit slick].freeze
+    PER_PAGE = 25
+    SNAPSHOT_AGE = 1.week
+
+    attr_reader :group, :year, :wind_cancellation, :gender
+
+    def initialize(group, year: nil, wind_cancellation: false, gender: nil, pages: {})
+      @group = group
+      @year = normalize_year(year)
+      @wind_cancellation = wind_cancellation
+      @gender = gender if VirtualCompetition::Ranking::GENDERS.include?(gender)
+      @pages = pages
+    end
+
+    def categories
+      @categories ||= SUIT_KINDS.filter_map { |suit_kind| build_category(suit_kind) }
+    end
+
+    def category(suit_kind) = categories.find { |category| category.suit_kind == suit_kind }
+
+    def populated_categories = categories.select { |category| category.rows.any? }
+
+    delegate :any?, to: :categories
+
+    def columns_count = (DISCIPLINES.size * 2) + 4
+
+    def gender_options = [nil, *VirtualCompetition::Ranking::GENDERS]
+
+    def show_rank_changes? = year.present? && !wind_cancellation
+
+    def overall? = year.nil?
+
+    def competitions = @competitions ||= group.virtual_competitions.where(discipline: DISCIPLINES).to_a
+
+    private
+
+    def normalize_year(year)
+      year = year.to_s.presence&.to_i
+      year if year && group.years.include?(year)
+    end
+
+    def build_category(suit_kind)
+      by_discipline = competitions.select { |competition| competition.suits_kind == suit_kind }
+                                  .index_by(&:discipline)
+      return unless DISCIPLINES.all? { |discipline| by_discipline.key?(discipline) }
+
+      by_discipline = by_discipline.slice(*DISCIPLINES)
+
+      Category.new(
+        self,
+        suit_kind,
+        by_discipline,
+        standings_for(by_discipline),
+        page: page_for(suit_kind)
+      )
+    end
+
+    def standings_for(competitions_by_discipline)
+      Standings.new(
+        competitions_by_discipline,
+        top_scores(competitions_by_discipline.values),
+        previous_scores(competitions_by_discipline.values),
+        gender:
+      )
+    end
+
+    def page_for(suit_kind) = [@pages[suit_kind].to_s.to_i, 1].max
+
+    def top_scores(competitions)
+      scores =
+        if year
+          VirtualCompetition::AnnualTopScore.with_wind_cancellation(wind_cancellation).for_year(year)
+        else
+          VirtualCompetition::PersonalTopScore.all
+        end
+
+      load_scores(scores, competitions)
+    end
+
+    def previous_scores(competitions)
+      return {} unless show_rank_changes?
+
+      scores = VirtualCompetition::AnnualTopScore.at_snapshot(SNAPSHOT_AGE.ago).for_year(year)
+
+      load_scores(scores, competitions)
+    end
+
+    def load_scores(scores, competitions)
+      scores
+        .where(virtual_competition_id: competitions.map(&:id))
+        .wind_cancellation(wind_cancellation)
+        .includes(:track, :suit, profile: :country)
+        .group_by(&:virtual_competition_id)
+    end
+  end
+end

--- a/app/models/virtual_competition/group/scoreboard/category.rb
+++ b/app/models/virtual_competition/group/scoreboard/category.rb
@@ -1,0 +1,31 @@
+class VirtualCompetition::Group::Scoreboard
+  class Category
+    attr_reader :scoreboard, :suit_kind, :competitions, :standings, :page
+
+    delegate :group, :show_rank_changes?, :columns_count, to: :scoreboard
+
+    def initialize(scoreboard, suit_kind, competitions, standings, page: 1)
+      @scoreboard = scoreboard
+      @suit_kind = suit_kind
+      @competitions = competitions
+      @standings = standings
+      @page = page
+    end
+
+    def name = I18n.t("virtual_competitions.suit_kinds.#{suit_kind}")
+
+    def to_param = suit_kind
+
+    def competition(discipline) = competitions[discipline]
+
+    def rows = @rows ||= standings.rows.first(page * PER_PAGE)
+
+    def rows_on_page = standings.rows.slice((page - 1) * PER_PAGE, PER_PAGE) || []
+
+    def more? = standings.rows.size > rows.size
+
+    def next_page = page + 1
+
+    def podium? = standings.rows.size >= 3
+  end
+end

--- a/app/models/virtual_competition/group/scoreboard/row.rb
+++ b/app/models/virtual_competition/group/scoreboard/row.rb
@@ -1,0 +1,45 @@
+class VirtualCompetition::Group::Scoreboard
+  class Row
+    attr_accessor :rank
+    attr_reader :profile_id, :scores, :competitions, :best_results
+
+    def initialize(profile_id, scores, competitions, best_results)
+      @profile_id = profile_id
+      @scores = scores
+      @competitions = competitions
+      @best_results = best_results
+    end
+
+    def profile = scores.each_value.first.profile
+
+    def score(discipline) = scores[discipline]
+
+    def best_in?(discipline)
+      result = score(discipline)&.result
+      result.present? && result == best_results[discipline]
+    end
+
+    def points_in_disciplines
+      @points_in_disciplines ||= competitions.keys.index_with { |discipline| points_in(discipline) }
+    end
+
+    def total_points = @total_points ||= points_in_disciplines.each_value.sum.round(1)
+
+    private
+
+    def points_in(discipline)
+      result = score(discipline)&.result
+      best = best_results[discipline]
+      return 0.0 if result.blank? || result.zero? || best.blank? || best.zero?
+
+      points =
+        if competitions[discipline].results_sort_order == 'ascending'
+          best / result * 100
+        else
+          result / best * 100
+        end
+
+      points.round(1)
+    end
+  end
+end

--- a/app/models/virtual_competition/group/scoreboard/standings.rb
+++ b/app/models/virtual_competition/group/scoreboard/standings.rb
@@ -1,0 +1,82 @@
+class VirtualCompetition::Group::Scoreboard
+  class Standings
+    attr_reader :competitions, :scores_by_competition, :previous_scores_by_competition, :gender
+
+    def initialize(competitions, scores_by_competition, previous_scores_by_competition = {}, gender: nil)
+      @competitions = competitions
+      @scores_by_competition = scores_by_competition
+      @previous_scores_by_competition = previous_scores_by_competition
+      @gender = gender
+    end
+
+    def rows = @rows ||= build_rows(qualified_scores(scores_by_competition))
+
+    def previous_rank(profile_id)
+      return if previous_scores_by_competition.empty?
+
+      previous_rows.find { |row| row.profile_id == profile_id }&.rank
+    end
+
+    def best_result(discipline) = best_results[discipline]
+
+    private
+
+    def previous_rows
+      @previous_rows ||= build_rows(qualified_scores(previous_scores_by_competition))
+    end
+
+    def best_results
+      @best_results ||= calculate_best_results(qualified_scores(scores_by_competition))
+    end
+
+    def build_rows(qualified)
+      bests = calculate_best_results(qualified)
+
+      qualified
+        .map { |profile_id, scores| Row.new(profile_id, scores, competitions, bests) }
+        .sort_by { |row| -row.total_points }
+        .tap { |sorted| assign_ranks(sorted) }
+    end
+
+    def qualified_scores(scores_by_competition)
+      by_profile = Hash.new { |hash, key| hash[key] = {} }
+
+      competitions.each do |discipline, competition|
+        scores_by_competition.fetch(competition.id, []).each do |score|
+          next if score.profile_id.nil?
+
+          by_profile[score.profile_id][discipline] = score
+        end
+      end
+
+      by_profile.select { |_profile_id, scores| complete?(scores) && matching_gender?(scores) }
+    end
+
+    def complete?(scores) = competitions.keys.all? { |discipline| scores.key?(discipline) }
+
+    def matching_gender?(scores)
+      return true if gender.blank?
+
+      scores.each_value.first.profile&.gender == gender
+    end
+
+    def calculate_best_results(qualified)
+      competitions.keys.index_with do |discipline|
+        results = qualified.each_value.filter_map { |scores| scores[discipline]&.result }
+        next if results.empty?
+
+        competitions[discipline].results_sort_order == 'ascending' ? results.min : results.max
+      end
+    end
+
+    def assign_ranks(rows)
+      return rows if rows.empty?
+
+      rows.first.rank = 1
+      rows.each_cons(2).with_index do |(previous, current), index|
+        tied = previous.total_points == current.total_points && current.total_points.positive?
+        current.rank = tied ? previous.rank : index + 2
+      end
+    end
+  end
+end

--- a/app/models/virtual_competitions/index.rb
+++ b/app/models/virtual_competitions/index.rb
@@ -27,7 +27,7 @@ module VirtualCompetitions
     private
 
     def grouped(scope)
-      scope.includes(:group, :place).group_by(&:group_name).transform_values do |competitions|
+      scope.includes(:place, group: :virtual_competitions).group_by(&:group).transform_values do |competitions|
         competitions.sort_by { |competition| [-athlete_count(competition), competition.name.to_s] }
       end
     end

--- a/app/policies/virtual_competition/group_policy.rb
+++ b/app/policies/virtual_competition/group_policy.rb
@@ -4,6 +4,6 @@ class VirtualCompetition::GroupPolicy < ApplicationPolicy
   end
 
   def show?
-    admin?
+    true
   end
 end

--- a/app/views/virtual_competitions/_group.html.erb
+++ b/app/views/virtual_competitions/_group.html.erb
@@ -1,7 +1,13 @@
 <div class="vc-group">
   <h3 class="vc-group__title">
-    <%= title %>
+    <%= group.name %>
     <span class="vc-group__count"><%= competitions.size %></span>
+
+    <% if group.combined_scoreboard? %>
+      <%= link_to t('virtual_competitions.index.combined_scoreboard'),
+                  virtual_competition_group_path(group),
+                  class: 'vc-group__combined-link' %>
+    <% end %>
   </h3>
   <div class="vc-cards">
     <% competitions.each do |competition| %>

--- a/app/views/virtual_competitions/groups/_actions_bar.html.erb
+++ b/app/views/virtual_competitions/groups/_actions_bar.html.erb
@@ -1,0 +1,23 @@
+<%# locals: (scoreboard:) %>
+<% base = scoreboard_filters %>
+
+<div class="card actions-bar vc-actions-bar">
+  <div class="vc-actions-bar__filters">
+    <div class="tab-bar tab-bar--gender">
+      <% scoreboard.gender_options.each do |gender| %>
+        <%= link_to t("virtual_competitions.show.genders.#{gender || 'open'}"),
+                    virtual_competition_group_path(scoreboard.group, **base.merge(gender:).compact_blank),
+                    class: class_names('tab-bar-item', 'active' => scoreboard.gender == gender) %>
+      <% end %>
+    </div>
+
+    <div class="tab-bar tab-bar--wind">
+      <%= link_to t('.raw'),
+                  virtual_competition_group_path(scoreboard.group, **base.except(:wind)),
+                  class: class_names('tab-bar-item', 'active' => !scoreboard.wind_cancellation) %>
+      <%= link_to t('.wind_cancelled'),
+                  virtual_competition_group_path(scoreboard.group, **base.merge(wind: 1)),
+                  class: class_names('tab-bar-item', 'active' => scoreboard.wind_cancellation) %>
+    </div>
+  </div>
+</div>

--- a/app/views/virtual_competitions/groups/_category_row.html.erb
+++ b/app/views/virtual_competitions/groups/_category_row.html.erb
@@ -1,0 +1,8 @@
+<%# locals: (category:) %>
+
+<tr class="scoreboard-category">
+  <td class="pinned-competitor-cell"></td>
+  <td class="scoreboard-section" colspan="<%= category.columns_count %>">
+    <span class="section-name"><%= category.name %></span>
+  </td>
+</tr>

--- a/app/views/virtual_competitions/groups/_load_more.html.erb
+++ b/app/views/virtual_competitions/groups/_load_more.html.erb
@@ -1,0 +1,14 @@
+<%# locals: (category:) %>
+
+<% if category.more? %>
+  <tr class="vc-group-scoreboard__more">
+    <td class="pinned-competitor-cell"></td>
+    <td colspan="<%= category.columns_count %>">
+      <%= link_to t('.load_more'),
+                  virtual_competition_group_category_path(category.group, category,
+                                                          page: category.next_page, **scoreboard_filters),
+                  class: 'button button--ghost button--sm',
+                  data: { turbo_stream: true } %>
+    </td>
+  </tr>
+<% end %>

--- a/app/views/virtual_competitions/groups/_navbar.html.erb
+++ b/app/views/virtual_competitions/groups/_navbar.html.erb
@@ -1,0 +1,14 @@
+<%# locals: (scoreboard:) %>
+<% filters = scoreboard_filters.except(:year) %>
+
+<div class="page-nav" data-controller="page-nav">
+  <%= link_to t('.overall'),
+              virtual_competition_group_path(scoreboard.group, **filters),
+              class: class_names('page-tab', 'page-tab-active' => scoreboard.overall?) %>
+
+  <% scoreboard.group.years.each do |year| %>
+    <%= link_to year,
+                virtual_competition_group_path(scoreboard.group, year:, **filters),
+                class: class_names('page-tab', 'page-tab-active' => scoreboard.year == year) %>
+  <% end %>
+</div>

--- a/app/views/virtual_competitions/groups/_row.html.erb
+++ b/app/views/virtual_competitions/groups/_row.html.erb
@@ -1,0 +1,50 @@
+<%# locals: (row:, category:) %>
+
+<% on_podium = category.podium? && row.rank <= 3 && row.total_points.positive? %>
+<% previous_rank = category.show_rank_changes? ? category.standings.previous_rank(row.profile_id) : nil %>
+
+<tr class="<%= class_names('scoreboard-competitor',
+                           'scoreboard-row--striped' => row.rank.even?,
+                           "podium-row--#{row.rank}" => on_podium) %>">
+  <%= render 'scoreboards/pinned_competitor_cell', name: row.profile.name.titleize %>
+
+  <td class="text-center rank-cell">
+    <% if on_podium %>
+      <span class="rank-badge rank-badge--<%= row.rank %>"><%= row.rank %></span>
+    <% else %>
+      <%= row.rank %>
+    <% end %>
+
+    <% if category.show_rank_changes? %>
+      <% if previous_rank.nil? %>
+        <span class="rank-new" data-controller="tooltip">•<span class="for-screen-reader"><%= t('virtual_competitions.scoreboard.rank_new') %></span></span>
+      <% elsif previous_rank > row.rank %>
+        <span class="rank-up" data-controller="tooltip">▲<span class="for-screen-reader"><%= t('virtual_competitions.scoreboard.rank_up', change: previous_rank - row.rank) %></span></span>
+      <% elsif previous_rank < row.rank %>
+        <span class="rank-down" data-controller="tooltip">▼<span class="for-screen-reader"><%= t('virtual_competitions.scoreboard.rank_down', change: row.rank - previous_rank) %></span></span>
+      <% else %>
+        <span class="rank-same">—</span>
+      <% end %>
+    <% end %>
+  </td>
+
+  <td class="competitor">
+    <%= link_to row.profile.name.titleize, profile_path(row.profile), class: 'competitor-profile' %>
+  </td>
+  <td class="text-center">
+    <span data-controller="tooltip">
+      <%= row.profile.country&.code %>
+      <span class="for-screen-reader"><%= row.profile.country&.name %></span>
+    </span>
+  </td>
+
+  <% category.competitions.each do |discipline, competition| %>
+    <% score = row.score(discipline) %>
+    <%= tag.td class: class_names('result-cell', 'text-green' => row.best_in?(discipline)) do %>
+      <%= link_to format_result(score.result, competition), score.track, class: 'result-show-cell' %>
+    <% end %>
+    <td class="text-right result-points-cell"><%= format('%.1f', row.points_in_disciplines[discipline]) %></td>
+  <% end %>
+
+  <td class="scoreboard-total-result"><%= format('%.1f', row.total_points) %></td>
+</tr>

--- a/app/views/virtual_competitions/groups/_scoreboard.html.erb
+++ b/app/views/virtual_competitions/groups/_scoreboard.html.erb
@@ -1,0 +1,23 @@
+<%# locals: (scoreboard:) %>
+
+<div class="scoreboard-container" data-controller="events--sticky-header">
+  <div class="scoreboard-scroll"
+       data-events--sticky-header-target="container"
+       data-action="scroll->events--sticky-header#on_horizontal_scroll">
+    <table class="scoreboard-table scoreboard-table--pinned-competitor vc-group-scoreboard-table"
+           data-events--sticky-header-target="table">
+      <%= render 'virtual_competitions/groups/scoreboard_header', scoreboard: %>
+
+      <% scoreboard.populated_categories.each do |category| %>
+        <tbody id="<%= group_category_rows_id(category) %>">
+          <%= render 'virtual_competitions/groups/category_row', category: %>
+          <%= render partial: 'virtual_competitions/groups/row', collection: category.rows,
+                     as: :row, locals: { category: } %>
+        </tbody>
+        <tbody id="<%= group_category_more_id(category) %>">
+          <%= render 'virtual_competitions/groups/load_more', category: %>
+        </tbody>
+      <% end %>
+    </table>
+  </div>
+</div>

--- a/app/views/virtual_competitions/groups/_scoreboard_header.html.erb
+++ b/app/views/virtual_competitions/groups/_scoreboard_header.html.erb
@@ -1,0 +1,19 @@
+<%# locals: (scoreboard:) %>
+
+<thead>
+  <tr>
+    <%= render 'scoreboards/pinned_competitor_header', label: t('.competitor'), rowspan: 2 %>
+    <th class="text-center" rowspan="2">#</th>
+    <th rowspan="2" colspan="2"><%= t('.competitor') %></th>
+    <% VirtualCompetition::Group::Scoreboard::DISCIPLINES.each do |discipline| %>
+      <th class="text-center" colspan="2"><%= t("disciplines.#{discipline}") %></th>
+    <% end %>
+    <th class="text-center" rowspan="2"><%= t('.total') %></th>
+  </tr>
+  <tr>
+    <% VirtualCompetition::Group::Scoreboard::DISCIPLINES.each do |discipline| %>
+      <th class="text-center"><%= combined_discipline_unit(discipline) %></th>
+      <th class="text-center">%</th>
+    <% end %>
+  </tr>
+</thead>

--- a/app/views/virtual_competitions/groups/categories/show.turbo_stream.erb
+++ b/app/views/virtual_competitions/groups/categories/show.turbo_stream.erb
@@ -1,0 +1,10 @@
+<%= turbo_stream.append group_category_rows_id(@category) do %>
+  <%= render partial: 'virtual_competitions/groups/row', collection: @category.rows_on_page,
+             as: :row, locals: { category: @category } %>
+<% end %>
+
+<%= turbo_stream.replace group_category_more_id(@category) do %>
+  <tbody id="<%= group_category_more_id(@category) %>">
+    <%= render 'virtual_competitions/groups/load_more', category: @category %>
+  </tbody>
+<% end %>

--- a/app/views/virtual_competitions/groups/show.html.erb
+++ b/app/views/virtual_competitions/groups/show.html.erb
@@ -1,13 +1,24 @@
-<div class="container">
-  <div class="page-header">
-    <h1>
-      Online competition // Group
-      <%= @group.name %>
-    </h1>
+<% provide :title, @scoreboard.group.name %>
+
+<div class="show-page">
+  <div class="show-page-header">
+    <h1 class="show-page-title"><%= @scoreboard.group.name %></h1>
+    <div class="show-page-info">
+      <div><%= t('.subtitle') %></div>
+    </div>
+
+    <%= render 'virtual_competitions/groups/navbar', scoreboard: @scoreboard %>
   </div>
 
-  <%= link_to t('general.back'), virtual_competition_groups_path, class: 'button' %>
-  <%= link_to t('general.edit'), edit_virtual_competition_group_path(@group), class: 'button' %>
-  <%= link_to t('general.delete'), virtual_competition_group_path(@group),
-              data: { turbo_method: :delete, turbo_confirm: t('general.confirm_delete') }, class: 'button button--danger' %>
+  <div class="show-page-content">
+    <%= render 'virtual_competitions/groups/actions_bar', scoreboard: @scoreboard %>
+
+    <% if @scoreboard.populated_categories.any? %>
+      <%= render 'virtual_competitions/groups/scoreboard', scoreboard: @scoreboard %>
+    <% else %>
+      <div class="card vc-group-scoreboard__blank">
+        <%= @scoreboard.any? ? t('.no_results') : t('.not_available') %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/virtual_competitions/index.html.erb
+++ b/app/views/virtual_competitions/index.html.erb
@@ -23,15 +23,15 @@
     <% end %>
   </div>
 
-  <% @index.active_groups.each do |title, competitions| %>
-    <%= render 'group', title: title, competitions: competitions, index: @index, finished: false %>
+  <% @index.active_groups.each do |group, competitions| %>
+    <%= render 'group', group: group, competitions: competitions, index: @index, finished: false %>
   <% end %>
 
   <% if @index.finished? %>
     <div class="vc-finished-section">
       <h3 class="vc-finished-section__title"><%= t('virtual_competitions.index.archived') %></h3>
-      <% @index.finished_groups.each do |title, competitions| %>
-        <%= render 'group', title: title, competitions: competitions, index: @index, finished: true %>
+      <% @index.finished_groups.each do |group, competitions| %>
+        <%= render 'group', group: group, competitions: competitions, index: @index, finished: true %>
       <% end %>
     </div>
   <% end %>

--- a/config/locales/views/virtual_competitions/de.yml
+++ b/config/locales/views/virtual_competitions/de.yml
@@ -1,6 +1,27 @@
 de:
   virtual_competitions:
+    suit_kinds:
+      wingsuit: 'Wingsuit'
+      monotrack: 'Monotrack'
+      tracksuit: 'Tracksuit'
+      slick: 'Slick'
+    groups:
+      show:
+        subtitle: 'Gesamtwertung aus Distanz, Geschwindigkeit und Zeit'
+        not_available: 'Keine Anzugklasse dieser Gruppe hat bisher alle drei Disziplinen.'
+        no_results: 'Kein Pilot hat für diese Auswahl Ergebnisse in allen drei Disziplinen.'
+      navbar:
+        overall: 'Gesamt'
+      actions_bar:
+        raw: 'Roh'
+        wind_cancelled: 'Windbereinigt'
+      scoreboard_header:
+        competitor: 'Teilnehmer'
+        total: 'Gesamt'
+      load_more:
+        load_more: 'Mehr laden'
     index:
+      combined_scoreboard: 'Gesamtwertung'
       show_archived: Archiv anzeigen
       archived: Archiv
       athletes:

--- a/config/locales/views/virtual_competitions/en.yml
+++ b/config/locales/views/virtual_competitions/en.yml
@@ -1,5 +1,25 @@
 en:
   virtual_competitions:
+    suit_kinds:
+      wingsuit: 'Wingsuit'
+      monotrack: 'Monotrack'
+      tracksuit: 'Tracksuit'
+      slick: 'Slick'
+    groups:
+      show:
+        subtitle: 'Combined standings across distance, speed and time'
+        not_available: 'No suit class in this group has all three disciplines yet.'
+        no_results: 'No pilot has results in all three disciplines for this selection.'
+      navbar:
+        overall: 'Overall'
+      actions_bar:
+        raw: 'Raw'
+        wind_cancelled: 'Wind adjusted'
+      scoreboard_header:
+        competitor: 'Competitor'
+        total: 'Total'
+      load_more:
+        load_more: 'Load more'
     show:
       jump_kinds:
         all: All
@@ -9,6 +29,7 @@ en:
         open: Open
         female: Female
     index:
+      combined_scoreboard: 'Combined scoreboard'
       show_archived: Show archived
       archived: Archived
       athletes:

--- a/config/locales/views/virtual_competitions/es.yml
+++ b/config/locales/views/virtual_competitions/es.yml
@@ -1,5 +1,25 @@
 es:
   virtual_competitions:
+    suit_kinds:
+      wingsuit: 'Wingsuit'
+      monotrack: 'Monotrack'
+      tracksuit: 'Tracksuit'
+      slick: 'Slick'
+    groups:
+      show:
+        subtitle: 'Clasificación combinada de distancia, velocidad y tiempo'
+        not_available: 'Ninguna clase de traje de este grupo tiene todavía las tres disciplinas.'
+        no_results: 'Ningún piloto tiene resultados en las tres disciplinas para esta selección.'
+      navbar:
+        overall: 'General'
+      actions_bar:
+        raw: 'Bruto'
+        wind_cancelled: 'Corregido por viento'
+      scoreboard_header:
+        competitor: 'Competidor'
+        total: 'Total'
+      load_more:
+        load_more: 'Cargar más'
     compare:
       start: Comparar tracks
       submit: Comparar
@@ -11,6 +31,7 @@ es:
         one: "Queda %{count} comparación gratuita"
         other: "Quedan %{count} comparaciones gratuitas"
     index:
+      combined_scoreboard: 'Clasificación combinada'
       show_archived: Mostrar archivados
       archived: Archivados
       athletes:

--- a/config/locales/views/virtual_competitions/fr.yml
+++ b/config/locales/views/virtual_competitions/fr.yml
@@ -1,6 +1,27 @@
 fr:
   virtual_competitions:
+    suit_kinds:
+      wingsuit: 'Wingsuit'
+      monotrack: 'Monotrack'
+      tracksuit: 'Tracksuit'
+      slick: 'Slick'
+    groups:
+      show:
+        subtitle: 'Classement combiné distance, vitesse et temps'
+        not_available: 'Aucune classe de combinaison de ce groupe n''a encore les trois disciplines.'
+        no_results: 'Aucun pilote n''a de résultats dans les trois disciplines pour cette sélection.'
+      navbar:
+        overall: 'Général'
+      actions_bar:
+        raw: 'Brut'
+        wind_cancelled: 'Corrigé du vent'
+      scoreboard_header:
+        competitor: 'Participant'
+        total: 'Total'
+      load_more:
+        load_more: 'Voir plus'
     index:
+      combined_scoreboard: 'Classement combiné'
       show_archived: Afficher les archives
       archived: Archives
       athletes:

--- a/config/locales/views/virtual_competitions/it.yml
+++ b/config/locales/views/virtual_competitions/it.yml
@@ -1,6 +1,27 @@
 it:
   virtual_competitions:
+    suit_kinds:
+      wingsuit: 'Wingsuit'
+      monotrack: 'Monotrack'
+      tracksuit: 'Tracksuit'
+      slick: 'Slick'
+    groups:
+      show:
+        subtitle: 'Classifica combinata di distanza, velocità e tempo'
+        not_available: 'Nessuna classe di tuta di questo gruppo ha ancora tutte e tre le discipline.'
+        no_results: 'Nessun pilota ha risultati in tutte e tre le discipline per questa selezione.'
+      navbar:
+        overall: 'Generale'
+      actions_bar:
+        raw: 'Grezzo'
+        wind_cancelled: 'Corretto per il vento'
+      scoreboard_header:
+        competitor: 'Concorrente'
+        total: 'Totale'
+      load_more:
+        load_more: 'Carica altri'
     index:
+      combined_scoreboard: 'Classifica combinata'
       show_archived: Mostra archiviati
       archived: Archiviati
       athletes:

--- a/config/locales/views/virtual_competitions/ru.yml
+++ b/config/locales/views/virtual_competitions/ru.yml
@@ -1,5 +1,25 @@
 ru:
   virtual_competitions:
+    suit_kinds:
+      wingsuit: 'Вингсьют'
+      monotrack: 'Монотрек'
+      tracksuit: 'Трексьют'
+      slick: 'Слик'
+    groups:
+      show:
+        subtitle: 'Общий зачёт по дальности, скорости и времени'
+        not_available: 'Ни в одном классе костюмов этой группы пока нет всех трёх дисциплин.'
+        no_results: 'Нет пилотов с результатами во всех трёх дисциплинах для этого фильтра.'
+      navbar:
+        overall: 'Общий зачёт'
+      actions_bar:
+        raw: 'Без поправки'
+        wind_cancelled: 'С поправкой на ветер'
+      scoreboard_header:
+        competitor: 'Участник'
+        total: 'Итого'
+      load_more:
+        load_more: 'Показать ещё'
     show:
       jump_kinds:
         all: Все
@@ -9,6 +29,7 @@ ru:
         open: Общий
         female: Женщины
     index:
+      combined_scoreboard: 'Общий зачёт'
       show_archived: Показать архив
       archived: Архив
       athletes:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -378,7 +378,11 @@ Skyderby::Application.routes.draw do
   resources :virtual_competitions, concerns: :sponsorable do
     scope module: :virtual_competitions do
       collection do
-        resources :groups, as: :virtual_competition_groups
+        resources :groups, as: :virtual_competition_groups do
+          scope module: :groups do
+            resources :categories, only: :show, param: :suit_kind
+          end
+        end
       end
 
       resource :person_details, only: :show

--- a/test/controllers/virtual_competitions/groups_controller_test.rb
+++ b/test/controllers/virtual_competitions/groups_controller_test.rb
@@ -1,14 +1,23 @@
 require 'test_helper'
 
 class VirtualCompetitions::GroupsControllerTest < ActionDispatch::IntegrationTest
-  test 'regular user #index' do
-    get virtual_competition_groups_path
-    assert_response :forbidden
+  setup do
+    @group = virtual_competition_groups(:cumulative)
+    @distance = virtual_competitions(:skydive_distance_wingsuit)
+    @speed = virtual_competitions(:skydive_speed_wingsuit)
+    @time = VirtualCompetition.create!(
+      name: 'Wingsuit time',
+      group: @group,
+      suits_kind: :wingsuit,
+      jumps_kind: :skydive,
+      discipline: :time,
+      period_from: Date.new(2015, 1, 1),
+      period_to: Date.new(2025, 1, 1)
+    )
   end
 
-  test 'regular user #show redirects to overall' do
-    group = virtual_competition_groups(:main)
-    get virtual_competition_group_path(id: group.id)
+  test 'regular user #index' do
+    get virtual_competition_groups_path
     assert_response :forbidden
   end
 
@@ -23,20 +32,100 @@ class VirtualCompetitions::GroupsControllerTest < ActionDispatch::IntegrationTes
   end
 
   test 'regular user #edit' do
-    group = virtual_competition_groups(:main)
-    get edit_virtual_competition_group_path(id: group.id)
+    get edit_virtual_competition_group_path(id: @group.id)
     assert_response :forbidden
   end
 
   test 'regular user #update' do
-    group = virtual_competition_groups(:main)
-    patch virtual_competition_group_path(id: group.id), params: { virtual_comp_group: { name: 'New name' } }
+    patch virtual_competition_group_path(id: @group.id), params: { virtual_comp_group: { name: 'New name' } }
     assert_response :forbidden
   end
 
   test 'regular user #destroy' do
-    group = virtual_competition_groups(:main)
-    delete virtual_competition_group_path(id: group.id)
+    delete virtual_competition_group_path(id: @group.id)
     assert_response :forbidden
+  end
+
+  test 'combined scoreboard is public' do
+    score(profiles(:john), distance: 3000, speed: 300, time: 90)
+
+    get virtual_competition_group_path(@group)
+
+    assert_response :success
+    assert_select 'table.vc-group-scoreboard-table'
+    assert_select 'tbody#group-category-wingsuit tr.scoreboard-competitor', 1
+  end
+
+  test 'renders a blank slate when no suit class has all three disciplines' do
+    get virtual_competition_group_path(virtual_competition_groups(:main))
+
+    assert_response :success
+    assert_select '.vc-group-scoreboard__blank'
+  end
+
+  test 'loads a further page of a category' do
+    26.times do |index|
+      score(Profile.create!(name: "Pilot #{index}"), distance: 3000 - index, speed: 300, time: 90)
+    end
+
+    get virtual_competition_group_path(@group)
+
+    assert_select 'tbody#group-category-wingsuit tr.scoreboard-competitor', 25
+    assert_select 'tbody#group-category-wingsuit-more a'
+
+    get virtual_competition_group_category_path(@group, 'wingsuit', page: 2),
+        headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+    assert_response :success
+    assert_match 'action="append" target="group-category-wingsuit"', response.body
+  end
+
+  test 'load more falls back to a full page when turbo is unavailable' do
+    26.times do |index|
+      score(Profile.create!(name: "Pilot #{index}"), distance: 3000 - index, speed: 300, time: 90)
+    end
+
+    get virtual_competition_group_category_path(@group, 'wingsuit', page: 2)
+
+    assert_redirected_to virtual_competition_group_path(
+      @group, pages: { 'wingsuit' => 2 }, anchor: 'group-category-wingsuit'
+    )
+
+    follow_redirect!
+    assert_select 'tbody#group-category-wingsuit tr.scoreboard-competitor', 26
+  end
+
+  test 'ignores non-scalar pagination params instead of erroring' do
+    score(profiles(:john), distance: 3000, speed: 300, time: 90)
+
+    get virtual_competition_group_path(@group, pages: { 'wingsuit' => { 'foo' => '1' } })
+    assert_response :success
+
+    get virtual_competition_group_category_path(@group, 'wingsuit', page: ['2'])
+    assert_response :redirect
+  end
+
+  test 'hides categories with no qualifying pilots' do
+    get virtual_competition_group_path(@group, gender: 'female')
+
+    assert_response :success
+    assert_select 'tbody#group-category-wingsuit', false
+    assert_select '.vc-group-scoreboard__blank'
+  end
+
+  private
+
+  def score(profile, results)
+    results.each do |discipline, result|
+      track = Track.create!(
+        pilot: profile,
+        kind: :skydive,
+        visibility: :public_track,
+        suit: suits(:apache),
+        recorded_at: Date.new(2024, 6, 1)
+      )
+
+      instance_variable_get(:"@#{discipline}").results.create!(track:, result:, wind_cancelled: false)
+    end
   end
 end

--- a/test/models/virtual_competition/group/scoreboard_test.rb
+++ b/test/models/virtual_competition/group/scoreboard_test.rb
@@ -1,0 +1,155 @@
+require 'test_helper'
+
+class VirtualCompetition::Group::ScoreboardTest < ActiveSupport::TestCase
+  setup do
+    @group = virtual_competition_groups(:cumulative)
+    @time = create_competition(:time, :wingsuit)
+    @distance = virtual_competitions(:skydive_distance_wingsuit)
+    @speed = virtual_competitions(:skydive_speed_wingsuit)
+  end
+
+  test 'skips suit classes without all three disciplines' do
+    assert_empty VirtualCompetition::Group::Scoreboard.new(@group).categories.map(&:suit_kind) & ['tracksuit']
+  end
+
+  test 'builds a wingsuit category once all three disciplines are present' do
+    score(@distance, profiles(:john), 3000)
+    score(@speed, profiles(:john), 300)
+    score(@time, profiles(:john), 90)
+
+    categories = VirtualCompetition::Group::Scoreboard.new(@group).categories
+
+    assert_equal ['wingsuit'], categories.map(&:suit_kind)
+    assert_equal [profiles(:john).id], categories.first.rows.map(&:profile_id)
+  end
+
+  test 'excludes pilots missing a discipline' do
+    score(@distance, profiles(:john), 3000)
+    score(@speed, profiles(:john), 300)
+    score(@time, profiles(:john), 90)
+
+    score(@distance, profiles(:travis), 2500)
+    score(@speed, profiles(:travis), 280)
+
+    rows = VirtualCompetition::Group::Scoreboard.new(@group).category('wingsuit').rows
+
+    assert_equal [profiles(:john).id], rows.map(&:profile_id)
+  end
+
+  test 'scores each discipline as a percentage of the best and sums them' do
+    score(@distance, profiles(:john), 3000)
+    score(@speed, profiles(:john), 300)
+    score(@time, profiles(:john), 90)
+
+    score(@distance, profiles(:travis), 1500)
+    score(@speed, profiles(:travis), 150)
+    score(@time, profiles(:travis), 45)
+
+    rows = VirtualCompetition::Group::Scoreboard.new(@group).category('wingsuit').rows
+
+    leader, runner_up = rows
+
+    assert_equal 1, leader.rank
+    assert_in_delta 300.0, leader.total_points, 0.01
+    assert_equal 2, runner_up.rank
+    assert_in_delta 150.0, runner_up.total_points, 0.01
+    assert_in_delta 50.0, runner_up.points_in_disciplines['distance'], 0.01
+  end
+
+  test 'gives tied totals an equal rank' do
+    [profiles(:john), profiles(:travis)].each do |profile|
+      score(@distance, profile, 3000)
+      score(@speed, profile, 300)
+      score(@time, profile, 90)
+    end
+
+    rows = VirtualCompetition::Group::Scoreboard.new(@group).category('wingsuit').rows
+
+    assert_equal [1, 1], rows.map(&:rank)
+  end
+
+  test 'filters by gender' do
+    female = create(:profile, name: 'Female pilot', gender: 'female')
+
+    score(@distance, profiles(:john), 3000)
+    score(@speed, profiles(:john), 300)
+    score(@time, profiles(:john), 90)
+
+    score(@distance, female, 2000)
+    score(@speed, female, 200)
+    score(@time, female, 60)
+
+    rows = VirtualCompetition::Group::Scoreboard.new(@group, gender: 'female').category('wingsuit').rows
+
+    assert_equal [female.id], rows.map(&:profile_id)
+    assert_in_delta 300.0, rows.first.total_points, 0.01
+  end
+
+  test 'year view honours the wind cancellation toggle' do
+    score(@distance, profiles(:john), 3000, wind_cancelled: true)
+    score(@speed, profiles(:john), 300, wind_cancelled: true)
+    score(@time, profiles(:john), 90, wind_cancelled: true)
+
+    raw = VirtualCompetition::Group::Scoreboard.new(@group, year: 2024).category('wingsuit')
+    assert_empty raw.rows
+
+    adjusted = VirtualCompetition::Group::Scoreboard
+               .new(@group, year: 2024, wind_cancellation: true)
+               .category('wingsuit')
+
+    assert_equal [profiles(:john).id], adjusted.rows.map(&:profile_id)
+  end
+
+  test 'ignores scores from tracks without a pilot' do
+    score(@distance, profiles(:john), 3000)
+    score(@speed, profiles(:john), 300)
+    score(@time, profiles(:john), 90)
+
+    score(@distance, nil, 2000)
+    score(@speed, nil, 200)
+    score(@time, nil, 60)
+
+    rows = VirtualCompetition::Group::Scoreboard.new(@group).category('wingsuit').rows
+
+    assert_equal [profiles(:john).id], rows.map(&:profile_id)
+  end
+
+  test 'falls back to the overall view for a year outside the group' do
+    assert_predicate VirtualCompetition::Group::Scoreboard.new(@group, year: 'garbage'), :overall?
+    assert_predicate VirtualCompetition::Group::Scoreboard.new(@group, year: '1066'), :overall?
+    assert_not VirtualCompetition::Group::Scoreboard.new(@group, year: '2024').overall?
+  end
+
+  test 'survives non-scalar page values' do
+    scoreboard = VirtualCompetition::Group::Scoreboard.new(@group, pages: { 'wingsuit' => ['2'] })
+
+    assert_equal 1, scoreboard.category('wingsuit').page
+  end
+
+  private
+
+  def create_competition(discipline, suits_kind)
+    VirtualCompetition.create!(
+      name: "#{suits_kind} #{discipline}",
+      group: @group,
+      suits_kind:,
+      jumps_kind: :skydive,
+      discipline:,
+      period_from: Date.new(2015, 1, 1),
+      period_to: Date.new(2025, 1, 1)
+    )
+  end
+
+  def score(competition, profile, result, wind_cancelled: false)
+    track = Track.create!(
+      pilot: profile,
+      name: ('Anonymous track' if profile.nil?),
+      kind: :skydive,
+      visibility: :public_track,
+      suit: suits(:apache),
+      recorded_at: Date.new(2024, 6, 1)
+    )
+
+    competition.results.create!(track:, result:, wind_cancelled:)
+  end
+end


### PR DESCRIPTION
Puts distance, speed and time side by side as columns with suit class as the category, so an online competition group reads like the wingsuit performance competition board instead of three separate rankings per suit.

## How it works

- **Columns** are fixed: distance, speed, time — each spanning a raw result and a % points cell.
- **Categories** are whatever suit classes the group actually has, ordered wingsuit → monotrack → tracksuit → slick. A suit class only appears once it has all three disciplines.
- **Points** follow the performance competition formula: `result / best_in_category * 100` per discipline, summed to a max of 300. Ties share a rank.
- **Eligibility**: only pilots with a result in all three disciplines are ranked.
- **Nothing new is stored.** `VirtualCompetition::Group::Scoreboard` sits on top of the existing `PersonalTopScore` / `AnnualTopScore` queries and joins them in memory by `profile_id`.

Overall + per-year tabs, gender filter, raw/wind-adjusted toggle, podium badges, and rank arrows on year tabs. Each category paginates at 25 with its own **Load more**.

`groups#show` replaces the old 13-line admin-only stub, so `GroupPolicy#show?` opens up and Edit/Delete move off the page — group editing stays on the admin index. The group headings on `/virtual_competitions` link to the board when a group has a complete suit class.

## Notes for review

**Load more is a Turbo Stream append, not a frame.** A `<turbo-frame>` inside a `<table>` gets hoisted out by the HTML parser, so each category is a `<tbody>` that rows are appended into. There's an HTML fallback that redirects to `?pages[wingsuit]=2`, so it degrades to a full page load without JS.

**`AnnualTopScore.with_wind_cancellation` is new and load-bearing.** `ranked_results_sql` bakes `wind_cancelled = false` into the subquery backing `default_scope`, so chaining `wind_cancellation(true)` filters a set that can never contain a match — the wind-adjusted year view came out empty even where wind-cancelled data existed. The new method builds the subquery with the flag instead. Existing callers are untouched.

**Rank arrows are still suppressed on the wind-adjusted view.** `at_snapshot` hardcodes `wind_cancelled: false`, so there's no week-ago baseline there. It's now a one-line change to enable if wanted — happy to do it in a follow-up.

## Needs a production data fix

`Distance challenge` (competition 5) has `results_sort_order: 'ascending'`, which ranks 12 m ahead of 5592 m. This predates the PR — its own `/virtual_competitions/5` page is wrong the same way — and the combined board faithfully mirrors it. Fixed in my local database only; production still needs:

```
VirtualCompetition.find(5).update_column(:results_sort_order, 'descending')
```

## Known, deliberately not addressed

`Scoreboard#competitions` filters on discipline but not `jumps_kind` or place, and `index_by(&:discipline)` keeps the last match — a group holding two competitions for the same (discipline, suit) pair would silently score against an arbitrary one. No current group trips this.

## Testing

- 6 model tests covering scoring, eligibility, ties, the gender filter, the wind-adjusted year view, pilotless tracks and year fallback
- 11 controller tests covering the public page, the blank slate, Load more (both Turbo Stream and HTML fallback), malformed pagination params and admin-only actions
- Existing virtual competition suite (90 runs) and the online competitions index system test (68 runs) pass
- RuboCop clean

Verified against a production data copy: leader on group 3 scores 93.4 + 100 + 95.4 = 288.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
