### PR TITLE
Hide task points column on single-task scoreboards

### DIFF
--- a/app/models/performance_competition/open_scoreboard.rb
+++ b/app/models/performance_competition/open_scoreboard.rb
@@ -12,8 +12,10 @@ class PerformanceCompetition::OpenScoreboard
   end
 
   def columns_count
-    @columns_count ||= rounds.count * 2 + rounds_by_discipline.count + 4
+    @columns_count ||= rounds.count * 2 + (show_discipline_points? ? rounds_by_discipline.count : 0) + 4
   end
+
+  def show_discipline_points? = rounds_by_discipline.size > 1
 
   def standings
     previous_standings = PerformanceCompetition::Scoreboard::Standings.new(

--- a/app/models/performance_competition/scoreboard.rb
+++ b/app/models/performance_competition/scoreboard.rb
@@ -12,8 +12,10 @@ class PerformanceCompetition::Scoreboard
   end
 
   def columns_count
-    @columns_count ||= rounds.count * 2 + rounds_by_discipline.count + 4
+    @columns_count ||= rounds.count * 2 + (show_discipline_points? ? rounds_by_discipline.count : 0) + 4
   end
+
+  def show_discipline_points? = rounds_by_discipline.size > 1
 
   def categories
     @categories ||=

--- a/app/models/performance_competition/task_scoreboard.rb
+++ b/app/models/performance_competition/task_scoreboard.rb
@@ -14,6 +14,8 @@ class PerformanceCompetition::TaskScoreboard
     @columns_count ||= rounds.count * 2 + 4
   end
 
+  def show_discipline_points? = false
+
   def standings
     previous_standings = PerformanceCompetition::Scoreboard::Standings.new(
       event.competitors,

--- a/app/views/performance_competitions/_scoreboard_header.html.erb
+++ b/app/views/performance_competitions/_scoreboard_header.html.erb
@@ -1,4 +1,5 @@
 <%# locals: (event:, scoreboard:, editable:) %>
+<% show_discipline_points = scoreboard.show_discipline_points? %>
 
 <thead>
   <tr>
@@ -6,7 +7,7 @@
     <th class="text-center" rowspan="3">#</th>
     <th rowspan="3" colspan="2"><%= t('activerecord.models.event/competitor') %></th>
     <% scoreboard.rounds_by_discipline.each do |discipline, rounds| %>
-      <th class="text-center" colspan="<%= rounds.count * 2 + 1 %>"><%= t('disciplines.' + discipline) %></th>
+      <th class="text-center" colspan="<%= rounds.count * 2 + (show_discipline_points ? 1 : 0) %>"><%= t('disciplines.' + discipline) %></th>
     <% end %>
     <th class="text-center" rowspan="3"><%= t('events.show.total') %></th>
   </tr>
@@ -15,7 +16,9 @@
       <% rounds.each do |round| %>
         <%= render 'performance_competitions/round_cell', event:, round:, editable: %>
       <% end %>
-      <th class="text-center" rowspan="2" data-discipline="<%= discipline %>" data-role="points">%</th>
+      <% if show_discipline_points %>
+        <th class="text-center" rowspan="2" data-discipline="<%= discipline %>" data-role="points">%</th>
+      <% end %>
     <% end %>
   </tr>
   <tr>

--- a/app/views/performance_competitions/_scoreboard_standings.html.erb
+++ b/app/views/performance_competitions/_scoreboard_standings.html.erb
@@ -4,6 +4,7 @@
 <% podium_enabled = standings.rows.size >= 3 %>
 <% time_machine = scoreboard.time_machine? %>
 <% show_delta = any_completed && scoreboard.completed_rounds.length > 1 && (!event.finished? || time_machine) %>
+<% show_discipline_points = scoreboard.show_discipline_points? %>
 
 <% standings.rows.each_with_index do |row, index| %>
   <% on_podium = podium_enabled && any_completed && row.total_points.to_f.positive? && row.rank <= 3 %>
@@ -71,11 +72,13 @@
           <% end %>
         <% end %>
       <% end %>
-      <td class="text-right discipline-points">
-        <% points_in_discipline = row.points_in_disciplines[discipline] %>
-        <% show_points = time_machine ? points_in_discipline.present? : rounds.any?(&:completed?) %>
-        <%= format('%.1f', points_in_discipline.to_f) if show_points %>
-      </td>
+      <% if show_discipline_points %>
+        <td class="text-right discipline-points">
+          <% points_in_discipline = row.points_in_disciplines[discipline] %>
+          <% show_points = time_machine ? points_in_discipline.present? : rounds.any?(&:completed?) %>
+          <%= format('%.1f', points_in_discipline.to_f) if show_points %>
+        </td>
+      <% end %>
     <% end %>
     <td class="scoreboard-total-result" data-total>
       <% show_total = time_machine ? scoreboard.completed_rounds.any? : any_completed %>


### PR DESCRIPTION
When a performance competition scores only one task, the per-task `%` total column shows exactly the same number as the overall **Total** column for every competitor. This drops it.

## Changes

- `PerformanceCompetition::Scoreboard` / `OpenScoreboard`: added `show_discipline_points?` (`rounds_by_discipline.size > 1`) and made `columns_count` account for it.
- `PerformanceCompetition::TaskScoreboard`: `show_discipline_points?` returns `false` — a task board is single-discipline by definition, and its `columns_count` already assumed no such column.
- `_scoreboard_header.html.erb`: the per-discipline points `<th>` is conditional, and the discipline group `colspan` shrinks accordingly.
- `_scoreboard_standings.html.erb`: matching `td.discipline-points` is conditional.

Both partials are shared, so this covers the main scoreboard, the by-category scoreboard, the open scoreboard, the by-task boards, and their time-machine variants.

## Verification

Checked locally against seed data:

- Event 22 (single Distance task) — duplicate column gone, Total intact.
- Event 26 (Speed/Distance/Time) — per-discipline `%` columns unchanged.
- By-task board for event 26 — redundant column gone.
- Time machine on event 22 — renders correctly, ranks and deltas intact.

The replay JS is unaffected: it targets `.result-points-cell` (per round) and `[data-total]`, not the discipline column.

RuboCop clean; `test/models/performance_competition` and `test/controllers/performance_competitions` pass (28 runs, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)