### PR TITLE
Polish combined scoreboard rows

### DIFF
--- a/app/assets/stylesheets/_scoreboards.css
+++ b/app/assets/stylesheets/_scoreboards.css
@@ -162,6 +162,20 @@
   width: 100%;
 }
 
+.scoreboard-table .result-gap {
+  padding: 0 0.5rem 0.25rem;
+  font-size: 0.6875rem;
+  line-height: 1;
+  font-weight: 400;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.scoreboard-table .result-gap--leader {
+  color: var(--green-90);
+  font-weight: 600;
+}
+
 .scoreboard-table .result-show-cell {
   display: flex;
   align-items: center;
@@ -547,20 +561,6 @@ td.scoreboard-total-result {
   border-right-color: transparent;
 }
 
-.qualification-scoreboard-table .result-gap {
-  padding: 0 0.5rem 0.25rem;
-  font-size: 0.6875rem;
-  line-height: 1;
-  font-weight: 400;
-  text-align: right;
-  font-variant-numeric: tabular-nums;
-}
-
-.qualification-scoreboard-table .result-gap--leader {
-  color: var(--green-90);
-  font-weight: 600;
-}
-
 .qualification-scoreboard-table .rank-badge {
   display: inline-flex;
   align-items: center;
@@ -748,16 +748,6 @@ td.scoreboard-total-result {
   color: var(--white);
 }
 
-.speed-skydiving-scoreboard-table tbody tr:nth-child(even) > td {
-  --pinned-tint: rgba(0, 0, 0, 0.015);
-  background-color: var(--pinned-tint);
-}
-
-.performance-competition-scoreboard-table tbody tr.scoreboard-row--striped > td {
-  --pinned-tint: rgba(0, 0, 0, 0.015);
-  background-color: var(--pinned-tint);
-}
-
 .performance-competition-scoreboard-table .competitor-profile {
   font-weight: 700;
 }
@@ -796,22 +786,14 @@ td.scoreboard-total-result {
   padding-top: 0.3rem;
 }
 
-.performance-competition-scoreboard-table .result-gap {
-  padding: 0 0.5rem 0.25rem;
-  font-size: 0.6875rem;
-  line-height: 1;
-  font-weight: 400;
-  text-align: right;
-  font-variant-numeric: tabular-nums;
-}
-
-.performance-competition-scoreboard-table .result-gap--leader {
-  color: var(--green-90);
-  font-weight: 600;
-}
-
 .team-standings-table tbody tr.team-row--striped > td {
   background-color: rgba(0, 0, 0, 0.015);
+}
+
+.scoreboard-table tbody tr.scoreboard-row--striped > td,
+.speed-skydiving-scoreboard-table tbody tr:nth-child(even) > td {
+  --pinned-tint: rgba(0, 0, 0, 0.015);
+  background-color: var(--pinned-tint);
 }
 
 .scoreboard-table tbody tr.podium-row--1 > td {

--- a/app/assets/stylesheets/_virtual_competition_group.css
+++ b/app/assets/stylesheets/_virtual_competition_group.css
@@ -1,15 +1,32 @@
-.vc-group-scoreboard-table tbody tr.scoreboard-row--striped > td {
-  --pinned-tint: rgba(0, 0, 0, 0.015);
-  background-color: var(--pinned-tint);
-}
-
 .vc-group-scoreboard-table .competitor-profile {
   font-weight: 700;
+}
+
+.vc-group-scoreboard-table .competitor-profile .contributor {
+  font-weight: inherit;
 }
 
 .vc-group-scoreboard-table a.result-show-cell,
 .vc-group-scoreboard-table td.scoreboard-total-result {
   font-weight: 700;
+}
+
+.vc-group-scoreboard-table a.result-show-cell {
+  background-color: transparent;
+  line-height: 1.2;
+  padding: 0.25rem 0.5rem 0.125rem;
+}
+
+.vc-group-scoreboard-table tbody td {
+  vertical-align: top;
+}
+
+.vc-group-scoreboard-table tbody td.result-cell {
+  height: auto;
+}
+
+.vc-group-scoreboard-table tbody tr.scoreboard-competitor > td:not(.result-cell, .pinned-competitor-cell) {
+  padding-top: 0.3rem;
 }
 
 .vc-group-scoreboard-table td.text-green,

--- a/app/helpers/virtual_competitions_helper.rb
+++ b/app/helpers/virtual_competitions_helper.rb
@@ -55,6 +55,10 @@ module VirtualCompetitionsHelper
     end
   end
 
+  def format_gap(gap, competition)
+    "#{gap.negative? ? '-' : '+'}#{format_result(gap.abs, competition)}"
+  end
+
   DISCIPLINE_ICONS = {
     'distance' => 'ruler-horizontal',
     'distance_in_time' => 'ruler-horizontal',

--- a/app/javascript/controllers/events/sticky_header_controller.js
+++ b/app/javascript/controllers/events/sticky_header_controller.js
@@ -71,7 +71,9 @@ export default class extends Controller {
 
     clone.style.width = this.tableTarget.offsetWidth + 'px'
 
-    const dataRow = this.tableTarget.querySelector('tbody tr:has(td + td)')
+    const dataRow = Array.from(this.tableTarget.querySelectorAll('tbody tr')).find(
+      row => row.cells.length > 1 && !Array.from(row.cells).some(cell => cell.colSpan > 1)
+    )
     if (dataRow) {
       let colgroup = clone.querySelector('colgroup')
       if (!colgroup) {

--- a/app/models/virtual_competition/group/scoreboard.rb
+++ b/app/models/virtual_competition/group/scoreboard.rb
@@ -92,7 +92,7 @@ class VirtualCompetition::Group
       scores
         .where(virtual_competition_id: competitions.map(&:id))
         .wind_cancellation(wind_cancellation)
-        .includes(:track, :suit, profile: :country)
+        .includes(:track, :suit, profile: %i[country owner])
         .group_by(&:virtual_competition_id)
     end
   end

--- a/app/models/virtual_competition/group/scoreboard/row.rb
+++ b/app/models/virtual_competition/group/scoreboard/row.rb
@@ -19,6 +19,14 @@ class VirtualCompetition::Group::Scoreboard
       result.present? && result == best_results[discipline]
     end
 
+    def gap_to_best(discipline)
+      result = score(discipline)&.result
+      best = best_results[discipline]
+      return if result.blank? || best.blank? || result == best
+
+      result - best
+    end
+
     def points_in_disciplines
       @points_in_disciplines ||= competitions.keys.index_with { |discipline| points_in(discipline) }
     end

--- a/app/views/virtual_competitions/groups/_row.html.erb
+++ b/app/views/virtual_competitions/groups/_row.html.erb
@@ -29,7 +29,11 @@
   </td>
 
   <td class="competitor">
-    <%= link_to row.profile.name.titleize, profile_path(row.profile), class: 'competitor-profile' %>
+    <%= link_to profile_path(row.profile), class: 'competitor-profile' do %>
+      <span class="<%= 'contributor' if row.profile.contributor? %>">
+        <%= row.profile.name.titleize %>
+      </span>
+    <% end %>
   </td>
   <td class="text-center">
     <span data-controller="tooltip">
@@ -40,8 +44,14 @@
 
   <% category.competitions.each do |discipline, competition| %>
     <% score = row.score(discipline) %>
+    <% gap = row.gap_to_best(discipline) %>
     <%= tag.td class: class_names('result-cell', 'text-green' => row.best_in?(discipline)) do %>
       <%= link_to format_result(score.result, competition), score.track, class: 'result-show-cell' %>
+      <% if row.best_in?(discipline) %>
+        <div class="result-gap result-gap--leader"><%= t('virtual_competitions.scoreboard.best') %></div>
+      <% elsif gap %>
+        <div class="result-gap text-gray"><%= format_gap(gap, competition) %></div>
+      <% end %>
     <% end %>
     <td class="text-right result-points-cell"><%= format('%.1f', row.points_in_disciplines[discipline]) %></td>
   <% end %>

--- a/config/locales/views/virtual_competitions/de.yml
+++ b/config/locales/views/virtual_competitions/de.yml
@@ -46,6 +46,7 @@ de:
         open: Offen
         female: Frauen
     scoreboard:
+      best: bester
       result: Ergebnis
       show_details: 'Klicke hier für Trackdetails'
       show_profile: 'Hier klicken für Profil'

--- a/config/locales/views/virtual_competitions/en.yml
+++ b/config/locales/views/virtual_competitions/en.yml
@@ -48,6 +48,7 @@ en:
     person_details:
       modal_title: Best results in competition
     scoreboard:
+      best: best
       result: Result
       show_details: Click to view track details
       show_profile: Click to view profile

--- a/config/locales/views/virtual_competitions/es.yml
+++ b/config/locales/views/virtual_competitions/es.yml
@@ -56,6 +56,7 @@ es:
         open: Abierta
         female: Femenina
     scoreboard:
+      best: mejor
       result: Result
       show_details: Haz click para ver el seguimiento
       show_profile: Haz click para ver el perfil

--- a/config/locales/views/virtual_competitions/fr.yml
+++ b/config/locales/views/virtual_competitions/fr.yml
@@ -48,6 +48,7 @@ fr:
     person_details:
       modal_title: Meilleurs résultats en compétition
     scoreboard:
+      best: meilleur
       result: Résultat
       show_details: Cliquer pour voir les détails de l'enregistrement
       show_profile: Cliquer pour voir le profil

--- a/config/locales/views/virtual_competitions/it.yml
+++ b/config/locales/views/virtual_competitions/it.yml
@@ -48,6 +48,7 @@ it:
     person_details:
       modal_title: Migliori risultati in competizione
     scoreboard:
+      best: migliore
       result: Risultato
       show_details: Clicca il dettaglio della traccia
       show_profile: Clicca per vedere il profilo

--- a/config/locales/views/virtual_competitions/ru.yml
+++ b/config/locales/views/virtual_competitions/ru.yml
@@ -50,6 +50,7 @@ ru:
     person_details:
       modal_title: Лучшие результаты в соревновании
     scoreboard:
+      best: лучший
       result: Результат
       show_details: Нажмите для просмотра деталей трека
       show_profile: Нажмите для просмотра профиля пилота


### PR DESCRIPTION
Follow-ups to #606, all on the online competition group combined scoreboard.

### Sticky header rendered as two columns

`onResize` built the clone's `<colgroup>` from `tbody tr:has(td + td)`. On this board the first such row is the *category* row (`WINGSUIT`) — a pinned cell plus one `colspan="10"` cell — so a `table-layout: fixed` clone got two columns instead of eleven. Now it picks the first body row with no spanning cell.

### Result cell ignored the row highlight

`.scoreboard-table a.result-show-cell` sets `background-color: var(--white)` and the link fills the whole `td`, so it painted over the podium/zebra/hover tint. The performance table already opted out with `transparent`; the group table now does too.

### Gap to best

Each result shows its gap to the category best, or `best` on the leader, mirroring `performance_competitions/open_scoreboards/_result_gap`. `Row#gap_to_best` returns `result - best`, and `format_gap` signs it — correct in both directions since `calculate_best_results` picks min for `ascending` competitions and max otherwise. Translated in all six locales.

### Pro subscriber names

Same gradient treatment the individual scoreboard uses. `Profile#contributor?` falls through to `owner&.subscribed?`, so `owner` is preloaded — without it a single page load issued 96 extra `User` queries.

### Cascade cleanup

Podium tints lost to the zebra rule, and hover lost to both: each table scoped its own stripe rule (3 classes) above the shared podium/hover rules (2 classes). Second place therefore never rendered silver, and even-numbered rows never showed the hover tint. The three duplicated stripe rules are now one shared rule placed immediately before podium and hover, all at equal specificity and ordered stripe → podium → hover. `.result-gap` / `.result-gap--leader` were duplicated verbatim under two table scopes and got the same treatment.

### Verification

Driven in the browser against `/virtual_competitions/groups/3`:

- sticky header clone matches the live table cell-for-cell on `left`/`width`
- podium rows compute gold / silver / bronze; result cells inherit the row tint
- gaps render (`-394`, `-49.5`, `best`), pinned cell back to `padding: 0`
- `User Load` per request: 96 → 3
- performance and qualification boards re-checked after the CSS dedup

`rubocop` clean, `yarn lint` clean, `test/models/virtual_competition/group` 10 runs / 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)