### PR TITLE
Reuse Google Maps instances across Turbo visits

### DIFF
--- a/app/javascript/controllers/places/finish_line_map_controller.js
+++ b/app/javascript/controllers/places/finish_line_map_controller.js
@@ -89,8 +89,7 @@ export default class extends Controller {
   }
 
   init_maps() {
-    document.addEventListener('maps_api:ready', this.on_maps_ready, { once: true })
-    init_maps_api()
+    init_maps_api().then(this.on_maps_ready)
   }
 
   set_center() {
@@ -119,6 +118,8 @@ export default class extends Controller {
   }
 
   on_maps_ready = () => {
+    if (!this.element.isConnected) return
+
     const options = {
       zoom: 2,
       center: new google.maps.LatLng(20, 20),

--- a/app/javascript/controllers/places/trajectories_map_controller.js
+++ b/app/javascript/controllers/places/trajectories_map_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 import { get } from '@rails/request.js'
 import initMapsApi from 'utils/google_maps_api'
+import { isTurboPreview } from 'utils/turbo_preview'
 import Trajectory from 'utils/tracks/map/trajectory'
 import Bounds from 'utils/maps/bounds'
 
@@ -12,6 +13,8 @@ export default class extends Controller {
   static values = { url: String, latitude: Number, longitude: Number }
 
   connect() {
+    if (isTurboPreview()) return
+
     Promise.all([initMapsApi(), this.loadTrajectories()])
       .then(() => this.render())
       .catch(() => this.hide())

--- a/app/javascript/controllers/tournaments/result_track_controller.js
+++ b/app/javascript/controllers/tournaments/result_track_controller.js
@@ -3,6 +3,7 @@ import { calculateBearing } from 'utils/tracks/pointHelpers'
 import { initGlideChart, initSpeedsChart, initAccuracyChart } from 'charts'
 import SideProjectionChart from 'utils/tracks/SideProjectionChart'
 import initMapsApi from 'utils/google_maps_api'
+import { isTurboPreview } from 'utils/turbo_preview'
 import Trajectory from 'utils/tracks/map/trajectory'
 import Bounds from 'utils/maps/bounds'
 import { fetchTrackPoints } from 'utils/tracks/trackData'
@@ -32,6 +33,8 @@ export default class extends PlaybackController {
   }
 
   connect() {
+    if (isTurboPreview()) return
+
     this.playing = false
     this.currentIndex = 0
 

--- a/app/javascript/controllers/tracks/base_jump_track_controller.js
+++ b/app/javascript/controllers/tracks/base_jump_track_controller.js
@@ -4,6 +4,8 @@ import SideProjectionChart from 'utils/tracks/SideProjectionChart'
 import initMapsApi from 'utils/google_maps_api'
 import Trajectory from 'utils/tracks/map/trajectory'
 import Bounds from 'utils/maps/bounds'
+import { acquireMap } from 'utils/maps/shared_map'
+import { isTurboPreview } from 'utils/turbo_preview'
 import { fetchTrackPoints } from 'utils/tracks/trackData'
 import { calculateBearing } from 'utils/tracks/pointHelpers'
 import { computeBaseJumpSummary } from 'utils/tracks/baseJumpSummary'
@@ -108,6 +110,7 @@ export default class extends PlaybackController {
   }
 
   connect() {
+    if (isTurboPreview()) return
     if (this.applyResultPreference()) return
 
     this.playing = false
@@ -128,6 +131,8 @@ export default class extends PlaybackController {
 
     Promise.all(fetches)
       .then(([pointsData, , compareData]) => {
+        if (!this.element.isConnected) return
+
         if (!pointsData.points || pointsData.points.length === 0) {
           this.showEmptyState('no_data')
           return
@@ -243,11 +248,13 @@ export default class extends PlaybackController {
       ? 'base-jump-result-marker base-jump-result-marker--compare'
       : 'base-jump-result-marker'
 
-    new google.maps.marker.AdvancedMarkerElement({
-      map: this.map,
-      position: { lat, lng: lon },
-      content: dot
-    })
+    this.sharedMap.add(
+      new google.maps.marker.AdvancedMarkerElement({
+        map: this.map,
+        position: { lat, lng: lon },
+        content: dot
+      })
+    )
   }
 
   showEmptyState(messageKey) {
@@ -902,15 +909,17 @@ export default class extends PlaybackController {
   drawFinishLine() {
     if (!this.hasFinishLine) return
 
-    this.finishLinePolyline = new google.maps.Polyline({
-      path: [
-        { lat: this.finishLineStartLatValue, lng: this.finishLineStartLonValue },
-        { lat: this.finishLineEndLatValue, lng: this.finishLineEndLonValue }
-      ],
-      strokeColor: FINISH_LINE_COLOR,
-      strokeOpacity: 1,
-      strokeWeight: 2
-    })
+    this.finishLinePolyline = this.sharedMap.add(
+      new google.maps.Polyline({
+        path: [
+          { lat: this.finishLineStartLatValue, lng: this.finishLineStartLonValue },
+          { lat: this.finishLineEndLatValue, lng: this.finishLineEndLonValue }
+        ],
+        strokeColor: FINISH_LINE_COLOR,
+        strokeOpacity: 1,
+        strokeWeight: 2
+      })
+    )
   }
 
   get showCompareOnMap() {
@@ -926,7 +935,7 @@ export default class extends PlaybackController {
   }
 
   initMap() {
-    this.map = new google.maps.Map(this.mapTarget, {
+    this.sharedMap = acquireMap(this.mapTarget, 'base-jump-track', {
       zoom: 2,
       center: new google.maps.LatLng(20, 20),
       mapTypeId: 'terrain',
@@ -935,6 +944,7 @@ export default class extends PlaybackController {
       streetViewControl: false,
       zoomControl: true
     })
+    this.map = this.sharedMap.map
   }
 
   drawTrajectory(points, { dashed = false, weight = 6 } = {}) {
@@ -972,6 +982,7 @@ export default class extends PlaybackController {
 
       const polyline = new google.maps.Polyline(options)
       polyline.setMap(this.map)
+      this.sharedMap.add(polyline)
     }
   }
 
@@ -1024,11 +1035,13 @@ export default class extends PlaybackController {
     img.style.height = '24px'
     img.style.transform = 'translateY(50%) rotate(-45deg)'
 
-    this.mapMarker = new google.maps.marker.AdvancedMarkerElement({
-      map: this.map,
-      position: { lat: this.points[0].latitude, lng: this.points[0].longitude },
-      content: img
-    })
+    this.mapMarker = this.sharedMap.add(
+      new google.maps.marker.AdvancedMarkerElement({
+        map: this.map,
+        position: { lat: this.points[0].latitude, lng: this.points[0].longitude },
+        content: img
+      })
+    )
 
     this.markerElement = img
   }
@@ -1042,14 +1055,16 @@ export default class extends PlaybackController {
     arrow.style.webkitMaskImage = `url(${this.locationArrowUrlValue})`
     arrow.style.transform = 'translateY(50%) rotate(-45deg)'
 
-    this.compareMapMarker = new google.maps.marker.AdvancedMarkerElement({
-      map: this.map,
-      position: {
-        lat: this.comparePoints[0].latitude,
-        lng: this.comparePoints[0].longitude
-      },
-      content: arrow
-    })
+    this.compareMapMarker = this.sharedMap.add(
+      new google.maps.marker.AdvancedMarkerElement({
+        map: this.map,
+        position: {
+          lat: this.comparePoints[0].latitude,
+          lng: this.comparePoints[0].longitude
+        },
+        content: arrow
+      })
+    )
 
     this.compareMarkerElement = arrow
   }
@@ -1418,6 +1433,13 @@ export default class extends PlaybackController {
 
   disconnect() {
     this.stopPlaybackLoop()
+
+    this.sharedMap?.release()
+    this.sharedMap = null
+    this.map = null
+    this.mapMarker = null
+    this.compareMapMarker = null
+    this.finishLinePolyline = null
 
     this.destroyChart(this.sideProjectionChart)
     this.destroyChart(this.glideChartTarget?.chart)

--- a/app/javascript/controllers/tracks/map_controller.js
+++ b/app/javascript/controllers/tracks/map_controller.js
@@ -2,13 +2,14 @@ import { Controller } from '@hotwired/stimulus'
 import initMapsApi from 'utils/google_maps_api'
 import Trajectory from 'utils/tracks/map/trajectory'
 import Bounds from 'utils/maps/bounds'
+import { acquireMap } from 'utils/maps/shared_map'
 
 export default class extends Controller {
   static targets = ['map', 'data']
 
   connect() {
     this.mapData = JSON.parse(this.dataTarget.textContent)
-    initMapsApi()
+    initMapsApi().then(() => this.onMapsReady())
   }
 
   renderMap() {
@@ -39,6 +40,7 @@ export default class extends Controller {
     })
 
     polyline.setMap(this.map)
+    this.sharedMap.add(polyline)
   }
 
   fitBounds() {
@@ -53,13 +55,16 @@ export default class extends Controller {
   }
 
   onMapsReady() {
+    if (!this.element.isConnected) return
+
     this.mapsReady = true
     this.initMap()
     this.renderMap()
   }
 
   initMap() {
-    this.map = new google.maps.Map(this.mapTarget, this.mapsOptions)
+    this.sharedMap = acquireMap(this.mapTarget, 'track-map', this.mapsOptions)
+    this.map = this.sharedMap.map
   }
 
   get mapsOptions() {
@@ -68,5 +73,11 @@ export default class extends Controller {
       center: new google.maps.LatLng(20, 20),
       mapTypeId: 'terrain'
     }
+  }
+
+  disconnect() {
+    this.sharedMap?.release()
+    this.sharedMap = null
+    this.map = null
   }
 }

--- a/app/javascript/controllers/tracks/skydive_performance_track_controller.js
+++ b/app/javascript/controllers/tracks/skydive_performance_track_controller.js
@@ -10,6 +10,7 @@ import {
 import { convertLength, lengthUnitLabel, convertSpeed, speedUnitLabel } from 'utils/units'
 import { computeSegmentAnalysis } from 'utils/tracks/skydiveSegments'
 import initMapsApi from 'utils/google_maps_api'
+import { isTurboPreview } from 'utils/turbo_preview'
 import cropPoints from 'utils/cropPoints'
 import downsamplePoints from 'utils/downsamplePoints'
 import calculateWindCancellation, { WeatherData } from 'utils/windCancellation'
@@ -112,6 +113,8 @@ export default class extends PlaybackController {
   }
 
   connect() {
+    if (isTurboPreview()) return
+
     this.playing = false
     this.currentIndex = 0
     this.stage = 'segments'

--- a/app/javascript/utils/google_maps_api.js
+++ b/app/javascript/utils/google_maps_api.js
@@ -1,12 +1,15 @@
 import { loadScript } from 'utils/load_external'
+import { isTurboPreview } from 'utils/turbo_preview'
 
 const getMapsApiKey = () => {
   const meta = document.querySelector('meta[name="maps-api-key"]')
   return meta ? meta.content : null
 }
 
-const initMapsApi = () =>
-  new Promise((resolve, reject) => {
+const initMapsApi = () => {
+  if (isTurboPreview()) return new Promise(() => {})
+
+  return new Promise((resolve, reject) => {
     const mapsApiKey = getMapsApiKey()
     if (!mapsApiKey) {
       reject(new Error('Maps API key not found'))
@@ -34,6 +37,7 @@ const initMapsApi = () =>
       loadScript(URL, { onError: reject })
     }
   })
+}
 
 export default initMapsApi
 

--- a/app/javascript/utils/maps/shared_map.js
+++ b/app/javascript/utils/maps/shared_map.js
@@ -1,0 +1,59 @@
+const instances = new Map()
+
+const detachOverlay = overlay => {
+  if (typeof overlay.setMap === 'function') {
+    overlay.setMap(null)
+  } else {
+    overlay.map = null
+  }
+}
+
+class SharedMapHandle {
+  constructor(entry) {
+    this.entry = entry
+    this.overlays = []
+  }
+
+  get map() {
+    return this.entry.map
+  }
+
+  add(overlay) {
+    this.overlays.push(overlay)
+    return overlay
+  }
+
+  clear() {
+    this.overlays.forEach(detachOverlay)
+    this.overlays = []
+  }
+
+  release() {
+    this.clear()
+
+    if (this.entry.handle !== this) return
+
+    this.entry.host.remove()
+    this.entry.handle = null
+  }
+}
+
+export const acquireMap = (container, key, options) => {
+  let entry = instances.get(key)
+
+  if (entry) {
+    entry.handle?.clear()
+  } else {
+    const host = document.createElement('div')
+    host.dataset.sharedMap = key
+    host.style.width = '100%'
+    host.style.height = '100%'
+    entry = { host, map: new google.maps.Map(host, options) }
+    instances.set(key, entry)
+  }
+
+  container.appendChild(entry.host)
+  entry.handle = new SharedMapHandle(entry)
+
+  return entry.handle
+}

--- a/app/javascript/utils/turbo_preview.js
+++ b/app/javascript/utils/turbo_preview.js
@@ -1,0 +1,2 @@
+export const isTurboPreview = () =>
+  document.documentElement.hasAttribute('data-turbo-preview')

--- a/app/views/tracks/maps/show.html.erb
+++ b/app/views/tracks/maps/show.html.erb
@@ -5,7 +5,7 @@
 
   <div class="track-show-content">
     <% if user_signed_in? %>
-      <div class="row" data-controller="tracks--map" data-action="maps_api:ready@window->tracks--map#onMapsReady">
+      <div class="row" data-controller="tracks--map">
         <script type="application/json" data-tracks--map-target="data">
           <%= raw render partial: 'tracks/maps/map_data', locals: { map_data: @map_data }, formats: [:json] %>
         </script>


### PR DESCRIPTION
Google bills a map load per `new google.maps.Map()`. Panning, zooming and tile fetches are free — only instantiation costs. Since Turbo never reloads the page, a user opening 20 tracks in a session was paying for 20 maps.

## What changed

**Instance pool** (`utils/maps/shared_map.js`) — one `google.maps.Map` per pool key, living in a detached host div that gets moved into the current page's container on each visit. Overlays registered through the handle are cleared when the map changes hands, and `release()` only detaches if the instance is still ours, so it survives Stimulus connecting the next page before disconnecting the previous one.

Pooled: base pro view (`base-jump-track`) and the track Google Maps tab (`track-map`). Finish line maps are deliberately left alone — few users reach them.

**Turbo preview** — `initMapsApi()` returns a never-settling promise during a cached preview render, so no map is built for a snapshot that's about to be thrown away. One guard instead of nine; the four controllers that still guard `connect()` do so because they also kick off point fetches and chart building.

**One-shot event → promise** — `tracks--map` and `places--finish-line-map` waited on `maps_api:ready`, which fires once per page load. On any Turbo navigation they built no map at all. Both now await the promise.

## Verification

Counter installed on `google.maps.Map` before the API script loads.

Route `/tracks/9257/map → /tracks/9257 → /tracks/9179/map → /tracks/9226 → /tracks/9318/map`, alternating both pooled map types:

- first pass: 2 map loads across 5 pages (one per pool key)
- second pass over the same route: **0**

Preview render observed via a `data-turbo-preview` mutation observer — 1 preview during the run, 0 maps created while it was up.

Trajectories, finish lines, playback and result markers render for the correct track with no leftovers from the previous one; `/tracks/9318/map` first point 61.8849, 6.8326 matches what's drawn. No console errors or unhandled rejections.

`yarn lint` and `yarn test` (57 tests) pass.

## Note

The two event-based pages were accidentally free on internal navigation because they built no map. They work now, so they will start costing their map loads — pooled in the case of the Google Maps tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)