### PR TITLE
Import terrain measurements from a CSV

### DIFF
--- a/app/assets/stylesheets/_forms.css
+++ b/app/assets/stylesheets/_forms.css
@@ -179,6 +179,13 @@
   border-bottom-right-radius: 0;
 }
 
+.form-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
 .form-section-title {
   color: var(--gray-80);
   font-weight: 500;

--- a/app/assets/stylesheets/_terrain_profiles.css
+++ b/app/assets/stylesheets/_terrain_profiles.css
@@ -90,6 +90,12 @@
   resize: vertical;
 }
 
+.terrain-profile-editor-error {
+  margin: 0;
+  color: var(--red-60);
+  font-size: 0.875rem;
+}
+
 .terrain-profile-editor-preview {
   height: var(--terrain-editor-height);
   border: var(--default-border);

--- a/app/javascript/controllers/terrain_profiles/form_controller.js
+++ b/app/javascript/controllers/terrain_profiles/form_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 import I18n from 'i18n'
 import FlightProfileChart from 'charts/FlightProfileChart'
-import { withExitPoint } from 'utils/terrainProfiles'
+import { parseTerrainCsv, withExitPoint } from 'utils/terrainProfiles'
 
 const MEASUREMENT_LINE = /^(-?\d+(?:[.,]\d+)?)[\s,;]+(-?\d+(?:[.,]\d+)?)$/
 
@@ -10,7 +10,9 @@ export default class extends Controller {
     'publishedCheckbox',
     'publicationFields',
     'measurementsText',
-    'preview'
+    'preview',
+    'csvFile',
+    'importError'
   ]
 
   connect() {
@@ -59,6 +61,46 @@ export default class extends Controller {
       .sort((a, b) => a.x - b.x)
 
     return withExitPoint(points)
+  }
+
+  openImportDialog() {
+    this.csvFileTarget.click()
+  }
+
+  async importCsv(event) {
+    const [file] = event.target.files
+    event.target.value = ''
+    if (!file) return
+
+    const measurements = await this.readMeasurements(file)
+
+    if (measurements.length === 0) {
+      this.showImportError()
+      return
+    }
+
+    this.hideImportError()
+    this.measurementsTextTarget.value = measurements
+      .map(({ altitude, distance }) => `${altitude} ${distance}`)
+      .join('\n')
+    this.renderPreview()
+  }
+
+  async readMeasurements(file) {
+    try {
+      return parseTerrainCsv(await file.text())
+    } catch {
+      return []
+    }
+  }
+
+  showImportError() {
+    this.importErrorTarget.textContent = I18n.t('terrain_profiles.form.import_csv_failed')
+    this.importErrorTarget.classList.remove('hide')
+  }
+
+  hideImportError() {
+    this.importErrorTarget.classList.add('hide')
   }
 
   togglePublication() {

--- a/app/javascript/utils/terrainProfiles.js
+++ b/app/javascript/utils/terrainProfiles.js
@@ -6,3 +6,44 @@ export const withExitPoint = points => {
 
   return [{ x: 0, y: 0 }, ...points]
 }
+
+const DELIMITERS = [';', '\t', ',']
+
+const toNumber = value => {
+  const normalized = value.trim().replace(',', '.')
+  if (!/^-?\d+(\.\d+)?$/.test(normalized)) return null
+
+  return Number(normalized)
+}
+
+const numericRows = (lines, delimiter) =>
+  lines
+    .map(line => line.split(delimiter))
+    .filter(columns => columns.length >= 2)
+    .map(columns => columns.slice(-2).map(toNumber))
+    .filter(([elevation, distance]) => elevation !== null && distance !== null)
+
+const parseWithBestDelimiter = lines =>
+  DELIMITERS.map(delimiter => numericRows(lines, delimiter)).reduce(
+    (best, rows) => (rows.length > best.length ? rows : best),
+    []
+  )
+
+export const parseTerrainCsv = text => {
+  const lines = text
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => line.length > 0)
+
+  const rows = parseWithBestDelimiter(lines)
+  if (rows.length < 2) return []
+
+  const [exitElevation] = rows[0]
+
+  return rows
+    .map(([elevation, distance]) => ({
+      altitude: Math.round(exitElevation - elevation),
+      distance: Math.round(distance)
+    }))
+    .sort((a, b) => a.distance - b.distance)
+}

--- a/app/javascript/utils/terrainProfiles.test.js
+++ b/app/javascript/utils/terrainProfiles.test.js
@@ -1,0 +1,44 @@
+import { test, describe, expect } from 'vitest'
+import { parseTerrainCsv } from './terrainProfiles'
+
+describe('parseTerrainCsv', () => {
+  test('rebases altitudes on the first row and keeps the last two columns', () => {
+    const csv = [
+      'Source: dtm',
+      'X;Y;Z;M',
+      '142448.81;6957045.37;1415.265991211;0',
+      '142447.81;6957045.39;1408.545776367;6.794209854685274',
+      '142446.81;6957045.41;1399.416625977;15.977966539358354'
+    ].join('\n')
+
+    expect(parseTerrainCsv(csv)).toEqual([
+      { altitude: 0, distance: 0 },
+      { altitude: 7, distance: 7 },
+      { altitude: 16, distance: 16 }
+    ])
+  })
+
+  test('ignores delimiters that only appear outside the data rows', () => {
+    const csv = ['Source: dtm; EPSG:25833', 'X,Y,Z,M', '1000,0', '990,40'].join('\n')
+
+    expect(parseTerrainCsv(csv)).toEqual([
+      { altitude: 0, distance: 0 },
+      { altitude: 10, distance: 40 }
+    ])
+  })
+
+  test('sorts measurements by distance', () => {
+    const csv = ['1000;20', '1010;0', '990;40'].join('\n')
+
+    expect(parseTerrainCsv(csv)).toEqual([
+      { altitude: -10, distance: 0 },
+      { altitude: 0, distance: 20 },
+      { altitude: 10, distance: 40 }
+    ])
+  })
+
+  test('returns nothing when there are no numeric rows', () => {
+    expect(parseTerrainCsv('name;value\nexit;top')).toEqual([])
+    expect(parseTerrainCsv('')).toEqual([])
+  })
+})

--- a/app/views/terrain_profiles/_form.html.erb
+++ b/app/views/terrain_profiles/_form.html.erb
@@ -46,8 +46,17 @@
   </section>
 
   <section class="form-section">
-    <h2 class="form-section-title"><%= t('.measurements') %></h2>
+    <div class="form-section-header">
+      <h2 class="form-section-title"><%= t('.measurements') %></h2>
+      <button type="button"
+              class="button button--outline button--sm"
+              data-action="terrain-profiles--form#openImportDialog">
+        <%= t('.import_csv') %>
+      </button>
+    </div>
     <p class="form-section-hint"><%= t('.measurements_hint') %></p>
+    <p class="terrain-profile-editor-error hide"
+       data-terrain-profiles--form-target="importError"></p>
 
     <div class="terrain-profile-editor">
       <%= f.text_area :measurements_text,
@@ -59,6 +68,14 @@
                         action: 'input->terrain-profiles--form#renderPreview'
                       } %>
       <div class="terrain-profile-editor-preview" data-terrain-profiles--form-target="preview"></div>
+
+      <%= file_field_tag :csv_file,
+                         accept: '.csv,text/csv',
+                         class: 'hide',
+                         data: {
+                           'terrain-profiles--form-target': 'csvFile',
+                           action: 'change->terrain-profiles--form#importCsv'
+                         } %>
     </div>
   </section>
 

--- a/config/locales/terrain_profiles.de.yml
+++ b/config/locales/terrain_profiles.de.yml
@@ -15,6 +15,8 @@ de:
       general: "Allgemein"
       measurements: "Geländemessungen"
       measurements_hint: "Eine Messung pro Zeile: Höhe und Entfernung vom Exit in Metern. Das Diagramm aktualisiert sich beim Tippen."
+      import_csv: "CSV importieren"
+      import_csv_failed: "Aus dieser Datei konnten keine Geländemessungen gelesen werden."
       ownership: "Eigentum"
       ownership_personal: "Persönlich"
       ownership_shared: "Öffentlich"

--- a/config/locales/terrain_profiles.en.yml
+++ b/config/locales/terrain_profiles.en.yml
@@ -15,6 +15,8 @@ en:
       general: "General"
       measurements: "Terrain measurements"
       measurements_hint: "One measurement per line: altitude and distance from the exit, in meters. The chart updates as you type."
+      import_csv: "Import CSV"
+      import_csv_failed: "Could not read terrain measurements from this file."
       ownership: "Ownership"
       ownership_personal: "Personal"
       ownership_shared: "Public"

--- a/config/locales/terrain_profiles.es.yml
+++ b/config/locales/terrain_profiles.es.yml
@@ -15,6 +15,8 @@ es:
       general: "General"
       measurements: "Mediciones del terreno"
       measurements_hint: "Una medición por línea: altitud y distancia desde la salida, en metros. El gráfico se actualiza mientras escribes."
+      import_csv: "Importar CSV"
+      import_csv_failed: "No se pudieron leer las mediciones del terreno de este archivo."
       ownership: "Propiedad"
       ownership_personal: "Personal"
       ownership_shared: "Público"

--- a/config/locales/terrain_profiles.fr.yml
+++ b/config/locales/terrain_profiles.fr.yml
@@ -15,6 +15,8 @@ fr:
       general: "Général"
       measurements: "Mesures du terrain"
       measurements_hint: "Une mesure par ligne : altitude et distance depuis la sortie, en mètres. Le graphique se met à jour à la saisie."
+      import_csv: "Importer un CSV"
+      import_csv_failed: "Impossible de lire les mesures du terrain dans ce fichier."
       ownership: "Propriété"
       ownership_personal: "Personnel"
       ownership_shared: "Public"

--- a/config/locales/terrain_profiles.it.yml
+++ b/config/locales/terrain_profiles.it.yml
@@ -15,6 +15,8 @@ it:
       general: "Generale"
       measurements: "Misurazioni del terreno"
       measurements_hint: "Una misurazione per riga: altitudine e distanza dall'exit, in metri. Il grafico si aggiorna mentre digiti."
+      import_csv: "Importa CSV"
+      import_csv_failed: "Impossibile leggere le misurazioni del terreno da questo file."
       ownership: "Proprietà"
       ownership_personal: "Personale"
       ownership_shared: "Pubblico"

--- a/config/locales/terrain_profiles.ru.yml
+++ b/config/locales/terrain_profiles.ru.yml
@@ -15,6 +15,8 @@ ru:
       general: "Основное"
       measurements: "Замеры рельефа"
       measurements_hint: "По одному замеру в строке: высота и расстояние от экзита в метрах. График обновляется по мере ввода."
+      import_csv: "Импорт CSV"
+      import_csv_failed: "Не удалось прочитать замеры рельефа из этого файла."
       ownership: "Владелец"
       ownership_personal: "Личный"
       ownership_shared: "Общий"


### PR DESCRIPTION
Terrain profiles were typed in by hand, one `altitude distance` pair per line. That is fine for a handful of points and tedious for the hundred-plus point surveys exported from a DTM.

## What changed

An **Import CSV** button sits on the terrain measurements section header, opposite the title. It opens the system file dialog, parses the file in the browser and replaces the textarea contents, so the live preview chart and the plain-text format remain the source of truth — nothing new is persisted and no endpoint was added.

Parsing lives in `parseTerrainCsv` (`app/javascript/utils/terrainProfiles.js`):

- The **last two columns** of every row are taken as elevation and distance.
- Surveys give elevation above sea level while profiles are stored relative to the exit, so altitudes are rebased on the first row (`Z[0] - Z[i]`, positive = below exit).
- Both values are rounded to **whole meters**, matching what `TerrainProfile#parse_measurement` and the integer columns store — so what you see after importing is what gets saved.
- The delimiter is whichever of `;`, tab or `,` yields the most rows ending in two numbers, rather than the first one found anywhere in the file. A semicolon in a header or comment line cannot make a comma-delimited file unreadable.
- Rows that do not end in two numbers are skipped, which drops header lines (`Source: dtm`, `X;Y;Z;M`) without special-casing them.

If nothing parses, or the file cannot be read at all, an inline message appears under the section hint and the textarea is left untouched.

Also adds a reusable `.form-section-header` utility (flex row, title left, actions right) for any form section that needs an action next to its heading.

## Notes for reviewers

- The imported values are integers on purpose. The model rounds to whole meters and the DB columns are integers, so showing decimals in the textarea would have been misleading.
- Import always **replaces** the textarea rather than appending.
- The hidden file input is cleared after every change event, so re-importing the same file works and nothing is submitted with the form.
- Translations added for all six locales.

## Testing

- `app/javascript/utils/terrainProfiles.test.js` covers rebasing, sorting by distance, the header-delimiter case and files with no numeric rows.
- Verified manually against a real Jurafjell DTM export: the textarea fills and the preview redraws; a garbage file and an unreadable file both surface the error with the previous measurements intact.
- `yarn lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)