### PR TITLE
Ignore WebGL init and fetch errors in Honeybadger

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -9,7 +9,11 @@ const honeybadgerApiKeyMeta = document.querySelector('meta[name="hb-api-key"]')
 if (currentEnvMeta && honeybadgerApiKeyMeta && currentEnvMeta.content === 'production') {
   Honeybadger.configure({
     apiKey: honeybadgerApiKeyMeta.content,
-    environment: currentEnvMeta.content
+    environment: currentEnvMeta.content,
+    ignorePatterns: [
+      /The browser supports WebGL, but initialization failed/i,
+      /Failed to fetch/i
+    ]
   })
 }
 


### PR DESCRIPTION
Two recurring client-side exceptions are environment noise rather than actionable bugs:

- `The browser supports WebGL, but initialization failed.` — Cesium failing to get a WebGL context on the user's machine
- `UnhandledPromiseRejectionWarning: TypeError: Failed to fetch` — aborted/offline network requests

Both are now filtered out via `ignorePatterns` in the browser Honeybadger config, so they are dropped before being sent.

Note: this only stops new reports; the existing occurrences still need to be resolved in the Honeybadger dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)