### PR TITLE
Convert speed skydiving units in the browser

### DIFF
--- a/app/helpers/units_helper.rb
+++ b/app/helpers/units_helper.rb
@@ -17,17 +17,17 @@ module UnitsHelper
 
   def speed_skydiving_imperial? = Current.speed_skydiving_units.imperial?
 
-  def speed_skydiving_speed(speed_kmh)
-    return if speed_kmh.nil?
-
-    speed_skydiving_imperial? ? kmh_to_mph(speed_kmh) : speed_kmh
+  def speed_kmh_value_tag(speed_kmh, precision: 2)
+    tag.span(
+      number_with_precision(speed_kmh, precision:),
+      data: { speed_units_target: 'value', speed_kmh:, precision: }
+    )
   end
 
-  def speed_skydiving_speed_with_unit(speed_kmh, precision: 2)
-    key = speed_skydiving_imperial? ? 'mph' : 'kmh'
+  def speed_kmh_with_unit(speed_kmh, precision: 2)
     t(
-      "speed_skydiving_competitions.display.#{key}",
-      speed: number_with_precision(speed_skydiving_speed(speed_kmh), precision:)
+      'speed_skydiving_competitions.display.kmh',
+      speed: number_with_precision(speed_kmh, precision:)
     )
   end
 end

--- a/app/javascript/controllers/replay_scoreboard_controller.js
+++ b/app/javascript/controllers/replay_scoreboard_controller.js
@@ -178,10 +178,10 @@ export default class extends Controller {
       const newAvgCell = newRow.querySelector('[data-avg]')
 
       if (totalCell && newTotalCell) {
-        totalCell.textContent = newTotalCell.textContent
+        totalCell.innerHTML = newTotalCell.innerHTML
       }
       if (avgCell && newAvgCell) {
-        avgCell.textContent = newAvgCell.textContent
+        avgCell.innerHTML = newAvgCell.innerHTML
       }
     }
   }

--- a/app/javascript/controllers/speed_units_controller.js
+++ b/app/javascript/controllers/speed_units_controller.js
@@ -1,0 +1,75 @@
+import { Controller } from '@hotwired/stimulus'
+import { convertSpeed, speedUnitLabel } from 'utils/units'
+
+export default class extends Controller {
+  static targets = ['value', 'label', 'option']
+
+  connect() {
+    this.onMorph = this.onMorph.bind(this)
+    this.element.addEventListener('turbo:morph-element', this.onMorph)
+  }
+
+  disconnect() {
+    this.element.removeEventListener('turbo:morph-element', this.onMorph)
+  }
+
+  valueTargetConnected(target) {
+    this.convertValue(target)
+  }
+
+  labelTargetConnected(target) {
+    this.convertLabel(target)
+  }
+
+  optionTargetConnected(target) {
+    this.markOption(target)
+  }
+
+  onMorph() {
+    if (this.refreshPending) return
+
+    this.refreshPending = true
+    queueMicrotask(() => {
+      this.refreshPending = false
+      this.valueTargets.forEach(target => this.convertValue(target))
+      this.labelTargets.forEach(target => this.convertLabel(target))
+      this.optionTargets.forEach(target => this.markOption(target))
+    })
+  }
+
+  markOption(target) {
+    target.classList.toggle('active', target.dataset.units === this.units)
+  }
+
+  convertValue(target) {
+    const speed = this.speedFor(target)
+    if (speed === null) return
+
+    target.textContent = speed.toFixed(this.precisionFor(target))
+  }
+
+  convertLabel(target) {
+    const speed = this.speedFor(target)
+    if (speed === null) return
+
+    const value = speed.toFixed(this.precisionFor(target))
+    target.dataset.result = `${value} ${speedUnitLabel(this.units)}`
+  }
+
+  speedFor(target) {
+    const kmh = parseFloat(target.dataset.speedKmh)
+    if (Number.isNaN(kmh)) return null
+
+    return convertSpeed(kmh, this.units)
+  }
+
+  precisionFor(target) {
+    const precision = parseInt(target.dataset.precision)
+    return Number.isNaN(precision) ? 2 : precision
+  }
+
+  get units() {
+    const meta = document.querySelector('meta[name="speed-skydiving-units"]')
+    return meta?.content || 'metric'
+  }
+}

--- a/app/views/speed_skydiving_competitions/_actions_bar.html.erb
+++ b/app/views/speed_skydiving_competitions/_actions_bar.html.erb
@@ -57,7 +57,7 @@
       </div>
     <% end %>
 
-    <div data-controller="dropdown">
+    <div data-controller="dropdown speed-units">
       <button class="actions-bar-button" popovertarget="speed-units-menu-<%= event.id %>" type="button" aria-label="<%= t('general.settings') %>">
         <%= icon_tag 'gear-solid' %>
       </button>
@@ -69,13 +69,15 @@
                       method: :patch,
                       params: { units: 'metric' },
                       form: { data: { turbo_stream: true } },
-                      class: class_names('dropdown-item', Current.speed_skydiving_units.metric? && 'active') %>
+                      class: 'dropdown-item',
+                      data: { speed_units_target: 'option', units: 'metric' } %>
         <%= button_to t('tracks.show.m_units_imperial'),
                       speed_skydiving_competition_unit_settings_path(event),
                       method: :patch,
                       params: { units: 'imperial' },
                       form: { data: { turbo_stream: true } },
-                      class: class_names('dropdown-item', Current.speed_skydiving_units.imperial? && 'active') %>
+                      class: 'dropdown-item',
+                      data: { speed_units_target: 'option', units: 'imperial' } %>
       </div>
     </div>
   </div>

--- a/app/views/speed_skydiving_competitions/_head.html.erb
+++ b/app/views/speed_skydiving_competitions/_head.html.erb
@@ -2,4 +2,5 @@
 
 <% content_for :head do %>
   <meta property="twitter:card" content="summary_large_image">
+  <meta id="speed-skydiving-units" name="speed-skydiving-units" content="<%= Current.speed_skydiving_units %>">
 <% end %>

--- a/app/views/speed_skydiving_competitions/_result_cell.html.erb
+++ b/app/views/speed_skydiving_competitions/_result_cell.html.erb
@@ -13,7 +13,9 @@
     data-action="click->track-compare#selectRow"
     data-track-id="<%= result.track_id %>"
     data-pilot="<%= competitor.name %>"
-    data-result="<%= speed_skydiving_speed_with_unit(result.final_result) %>"
+    data-speed-units-target="label"
+    data-speed-kmh="<%= result.final_result %>"
+    data-result="<%= speed_kmh_with_unit(result.final_result) %>"
     data-kind="speed_skydiving"
   <% end %>
 >
@@ -22,12 +24,12 @@
                   method: :get, form: { data: { turbo_stream: true }, class: 'result-show-cell' } do %>
       <% if result.penalized? %>
         <span data-controller="tooltip">
-          <%= '%.2f' % speed_skydiving_speed(result.final_result) %>
+          <%= speed_kmh_value_tag result.final_result %>
           <sup class="text-danger">-<%= result.penalty_size.round %>%</sup>
-          <span class="for-screen-reader"><%= '%.2f' % speed_skydiving_speed(result.result) %> - <%= result.penalty_size.round %>%. Reason: <%= result.penalty_reason %></span>
+          <span class="for-screen-reader"><%= speed_kmh_value_tag result.result %> - <%= result.penalty_size.round %>%. Reason: <%= result.penalty_reason %></span>
         </span>
       <% else %>
-        <%= '%.2f' % speed_skydiving_speed(result.final_result) %>
+        <%= speed_kmh_value_tag result.final_result %>
       <% end %>
     <% end %>
   <% elsif !time_machine && editable %>

--- a/app/views/speed_skydiving_competitions/_scoreboard.html.erb
+++ b/app/views/speed_skydiving_competitions/_scoreboard.html.erb
@@ -4,7 +4,7 @@
 
 <% container_id = standings.until_round ? 'scoreboard-time-machine' : 'scoreboard'  %>
 <div class="scoreboard-container" id="<%= container_id %>"
-     data-controller="events--sticky-header">
+     data-controller="events--sticky-header speed-units">
   <div class="scoreboard-scroll"
        data-events--sticky-header-target="container"
        data-action="scroll->events--sticky-header#on_horizontal_scroll">
@@ -81,8 +81,8 @@
               <%= render 'speed_skydiving_competitions/result_cell', event:, standings:, round:, competitor:, result:, editable:, is_best:, is_worst: %>
             <% end %>
             <% if at_least_one_round_completed %>
-              <td class="text-right" data-total><%= '%.2f' % row[:total] %></td>
-              <td class="text-right" data-avg><%= '%.2f' % row[:average] %></td>
+              <td class="text-right" data-total><%= speed_kmh_value_tag row[:total] %></td>
+              <td class="text-right" data-avg><%= speed_kmh_value_tag row[:average] %></td>
             <% else %>
               <td data-total></td>
               <td data-avg></td>

--- a/app/views/speed_skydiving_competitions/open_scoreboards/_scoreboard.html.erb
+++ b/app/views/speed_skydiving_competitions/open_scoreboards/_scoreboard.html.erb
@@ -3,7 +3,7 @@
 <% standings = event.open_standings %>
 <% at_least_one_round_completed = standings.completed_rounds.length > 0 %>
 
-<div class="scoreboard-container" id="open-scoreboard">
+<div class="scoreboard-container" id="open-scoreboard" data-controller="speed-units">
   <table class="scoreboard-table">
     <thead>
       <tr>
@@ -32,8 +32,8 @@
             <%= render 'speed_skydiving_competitions/result_cell', event:, standings:, round:, competitor:, result:, editable: %>
           <% end %>
           <% if at_least_one_round_completed %>
-            <td class="text-right"><%= '%.2f' % row[:total] %></td>
-            <td class="text-right"><%= '%.2f' % row[:average] %></td>
+            <td class="text-right"><%= speed_kmh_value_tag row[:total] %></td>
+            <td class="text-right"><%= speed_kmh_value_tag row[:average] %></td>
           <% else %>
             <td></td>
             <td></td>

--- a/app/views/speed_skydiving_competitions/unit_settings/update.turbo_stream.erb
+++ b/app/views/speed_skydiving_competitions/unit_settings/update.turbo_stream.erb
@@ -1,6 +1,10 @@
 <% standings = @event.standings %>
 <% editable = @event.editable? %>
 
+<%= turbo_stream.replace 'speed-skydiving-units' do %>
+  <meta id="speed-skydiving-units" name="speed-skydiving-units" content="<%= Current.speed_skydiving_units %>">
+<% end %>
+
 <%= turbo_stream.replace 'actions-bar' do %>
   <%= render 'speed_skydiving_competitions/actions_bar', event: @event, standings:, editable: %>
 <% end %>

--- a/test/requests/speed_skydiving_competitions/scoreboard_units_test.rb
+++ b/test/requests/speed_skydiving_competitions/scoreboard_units_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+class SpeedSkydivingCompetitions::ScoreboardUnitsTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = speed_skydiving_competitions(:nationals)
+    @result = speed_skydiving_competition_results(:hinton_round_1)
+  end
+
+  test 'page exposes the preferred units to the client' do
+    user = users(:regular_user)
+    user.setting.update!(speed_skydiving_units: 'imperial')
+    sign_in user
+
+    get speed_skydiving_competition_open_scoreboard_path(@event)
+
+    assert_response :success
+    assert_match 'name="speed-skydiving-units" content="imperial"', response.body
+  end
+
+  test 'results are rendered in km/h regardless of the preferred units' do
+    user = users(:event_responsible)
+    user.setting.update!(speed_skydiving_units: 'imperial')
+    sign_in user
+
+    get speed_skydiving_competition_path(@event)
+
+    assert_response :success
+    assert_match "data-speed-kmh=\"#{@result.final_result}\"", response.body
+    assert_match ">#{format('%.2f', @result.final_result)}</span>", response.body
+  end
+
+  test 'broadcast template renders outside of a request' do
+    Current.reset
+
+    html =
+      ApplicationController.render(
+        template: 'speed_skydiving_competitions/broadcasts/open_scoreboard',
+        formats: [:turbo_stream],
+        locals: { event: @event, editable: true }
+      )
+
+    assert_match "data-speed-kmh=\"#{@result.final_result}\"", html
+  end
+end


### PR DESCRIPTION
Fixes Honeybadger [#132777664](https://app.honeybadger.io/projects/52392/faults/132777664) — `ActionView::Template::Error: undefined method 'inquiry' for nil` in `Turbo::Streams::BroadcastJob` (17k occurrences).

## Why

Scoreboard broadcasts are sent to a single stream per event (`[event, :open_scoreboard, :editable|:read_only]`) — there is no units dimension, so every subscriber gets the same HTML. Rendering results in the broadcaster's units would push metric values to viewers who selected imperial. And inside a `BroadcastJob` there is no request, so `Current.speed_skydiving_units` is `nil` and `super.inquiry` raised.

## What changed

The server always renders canonical km/h and attaches the raw value; the viewer's browser converts.

- `_result_cell.html.erb` wraps numbers in `speed_kmh_value_tag` → `<span data-speed-units-target="value" data-speed-kmh="351.462">351.46</span>`; the `<td>` carries `data-speed-kmh` for the track-compare label.
- New `speed-units` Stimulus controller on each scoreboard container reads `<meta name="speed-skydiving-units">` and converts through the existing `utils/units` helpers. It runs on `targetConnected` (initial load, Turbo replaces, time-machine replay injections) and on `turbo:morph-element` (broadcasts), always recomputing from `data-speed-kmh` — so a metric broadcast morphing in never sticks.
- `units_helper.rb`: dropped `speed_skydiving_speed` / `speed_skydiving_speed_with_unit` (they read `Current`), added the unit-free `speed_kmh_value_tag` / `speed_kmh_with_unit`. No broadcast-reachable view reads `Current` anymore.
- Totals and averages now use the same tag — they were left in km/h even in imperial mode before, which looked wrong next to converted results.
- The units dropdown active state is client-side too: the actions-bar broadcast in `statuses_controller` leaked the sender's units the same way.
- `replay_scoreboard_controller#updateRowTotals` copies `innerHTML` instead of `textContent`, so the value spans survive a time-machine replay.

## Notes for review

- Verified in the browser: metric renders 351.46 km/h; switching to imperial updates the meta tag, dropdown, cells and totals (218.39 mph / 436.77); a simulated morph broadcast carrying server metric HTML re-converts to imperial; replay injections come out converted; switching back round-trips.
- Tests cover the meta tag, the km/h-regardless-of-preference markup, and rendering the broadcast template with `Current.reset` — the exact job condition that was crashing.
- Not touched: the teams scoreboard still shows raw km/h, it never went through the units helper.
- There is a backlog of poisoned jobs (the reported one was enqueued 2026-07-26, retry #23); they will succeed once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)