### PR TITLE
Add a slideshow display to Hungary Boogie events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 /.bundle
 
 # Ignore all logfiles and tempfiles.
-/log/*.log
+/log/*.log*
 /tmp
 .byebug_history
 

--- a/app/assets/stylesheets/display/application.css
+++ b/app/assets/stylesheets/display/application.css
@@ -1298,7 +1298,8 @@ body {
   font-variant-numeric: tabular-nums;
 }
 
-.display-performance .display-replay-stat-value .num {
+.display-performance .display-replay-stat-value .num,
+.display-boogie .display-replay-stat-value .num {
   font-size: calc(40 * var(--px));
   font-variant-numeric: tabular-nums;
 }
@@ -1378,7 +1379,8 @@ body {
 }
 
 /* ---- Performance competition countdown: top-right corner, no blur ---- */
-.display-performance .display-replay-countdown {
+.display-performance .display-replay-countdown,
+.display-boogie .display-replay-countdown {
   inset: auto;
   top: calc(66 * var(--px));
   right: calc(26 * var(--px));
@@ -1386,11 +1388,13 @@ body {
   backdrop-filter: none;
 }
 
-.display-performance .display-replay-countdown .count {
+.display-performance .display-replay-countdown .count,
+.display-boogie .display-replay-countdown .count {
   font-size: calc(76 * var(--px));
 }
 
-.display-performance .display-replay-countdown.is-rate .count {
+.display-performance .display-replay-countdown.is-rate .count,
+.display-boogie .display-replay-countdown.is-rate .count {
   font-size: calc(46 * var(--px));
   color: var(--text);
   text-shadow: none;
@@ -1559,4 +1563,25 @@ body {
   font-size: 14px;
   fill: #7dffa6;
   text-transform: uppercase;
+}
+
+/* ---- Hungary boogie leaderboard columns ---- */
+.display-boogie .display-lb-head,
+.display-boogie .display-lb-row {
+  grid-template-columns: calc(100 * var(--px)) 1fr calc(190 * var(--px)) calc(560 * var(--px));
+  gap: calc(18 * var(--px));
+}
+
+.display-boogie .display-lb-tiles {
+  grid-template-columns: repeat(6, 1fr);
+}
+
+/* ---- Hungary boogie participant slide ---- */
+.display-boogie .display-besttime-value .num {
+  font-size: calc(108 * var(--px));
+}
+
+.display-boogie .display-attempts-head,
+.display-boogie .display-attempts-row {
+  grid-template-columns: calc(180 * var(--px)) 1fr calc(200 * var(--px));
 }

--- a/app/controllers/boogies/competitors_controller.rb
+++ b/app/controllers/boogies/competitors_controller.rb
@@ -43,7 +43,7 @@ class Boogies::CompetitorsController < ApplicationController
 
   def competitor_params
     permitted = params.require(:competitor).permit(
-      :assigned_number, :section_id, :suit_id, :profile_id, :alias_id,
+      :assigned_number, :section_id, :suit_id, :profile_id, :alias_id, :photo,
       profile_attributes: %i[name country_id]
     )
 

--- a/app/controllers/boogies/displays_controller.rb
+++ b/app/controllers/boogies/displays_controller.rb
@@ -1,0 +1,15 @@
+module Boogies
+  class DisplaysController < ApplicationController
+    include BoogieContext
+
+    layout 'display'
+
+    before_action :set_event, :authorize_event_access!
+
+    def show
+      response.headers['X-FRAME-OPTIONS'] = 'ALLOWALL'
+
+      @display = Boogie::Display.new(@event)
+    end
+  end
+end

--- a/app/models/boogie/competitor.rb
+++ b/app/models/boogie/competitor.rb
@@ -2,6 +2,7 @@ class Boogie::Competitor < ApplicationRecord
   self.table_name = :event_competitors
 
   include EventOngoingValidation, CompetitorCountry, CompetitorAlias
+  include PhotoUploader::Attachment(:photo)
 
   belongs_to :event, class_name: 'Boogie', touch: true
   belongs_to :category, foreign_key: :section_id, inverse_of: :competitors
@@ -10,6 +11,8 @@ class Boogie::Competitor < ApplicationRecord
   belongs_to :team, optional: true
 
   has_many :results, dependent: :restrict_with_error
+
+  after_validation { photo_derivatives! if photo_changed? }
 
   scope :ordered,
         -> { left_joins(:profile, :competitor_alias).order(Arel.sql('COALESCE(profile_aliases.name, profiles.name)')) }

--- a/app/models/boogie/competitor/photo_uploader.rb
+++ b/app/models/boogie/competitor/photo_uploader.rb
@@ -1,0 +1,17 @@
+class Boogie::Competitor::PhotoUploader < Shrine
+  plugin :validation_helpers
+  plugin :pretty_location
+
+  Attacher.derivatives do |original|
+    vips = ImageProcessing::Vips.source(original)
+
+    {
+      medium: vips.resize_to_limit(800, 1000).call
+    }
+  end
+
+  Attacher.validate do
+    validate_max_size 5 * 1024 * 1024
+    validate_mime_type %w[image/jpeg image/png image/webp]
+  end
+end

--- a/app/models/boogie/display.rb
+++ b/app/models/boogie/display.rb
@@ -1,0 +1,141 @@
+class Boogie::Display < SimpleDelegator
+  PALETTE = %w[#470FF4 #F24C00 #36e07a #a855f7].freeze
+  MAX_FALLERS = 8
+
+  def initialize(event)
+    @event = event
+    super(event)
+  end
+
+  def categories
+    @categories ||= scoreboard.categories.filter_map do |category, standings|
+      rows = assign_ranks(standings.rows.map { |row| LeaderRow.new(row) }.select(&:scored?))
+      Category.new(category, rows, @event.number_of_results_for_total) if rows.any?
+    end
+  end
+
+  class Category
+    delegate :name, to: :record
+    delegate :size, to: :rows
+
+    def initialize(record, rows, counting_results)
+      @record = record
+      @rows = rows
+      @counting_results = counting_results
+    end
+
+    attr_reader :counting_results
+
+    def leaderboard = rows
+
+    def fallers
+      @fallers ||=
+        rows.first(MAX_FALLERS).each_with_index.filter_map do |row, index|
+          Faller.build(row, PALETTE[index % PALETTE.size])
+        end
+    end
+
+    def fall_pairs = fallers.each_slice(2).to_a
+
+    private
+
+    attr_reader :record, :rows
+  end
+
+  class LeaderRow
+    attr_accessor :rank
+
+    delegate :name, :country_code, :country_name, to: :competitor
+    delegate :competitor, :total_points, to: :row
+
+    def initialize(row)
+      @row = row
+    end
+
+    def scored? = scored_results.any?
+
+    def suit = [competitor.suit&.manufacturer_code, competitor.suit_name].compact.join(' ')
+
+    def photo_url = (competitor.photo_url(:medium) if competitor.photo)
+
+    def best = scored_results.max_by(&:result)
+
+    def best_round = best&.round_number
+
+    def jumps = scored_results.size
+
+    def attempts
+      @attempts ||=
+        scored_results.sort_by(&:round_number).map do |result|
+          Attempt.new(result.round_number, result.result, counting_results.include?(result), result == best)
+        end
+    end
+
+    private
+
+    attr_reader :row
+
+    def counting_results = @counting_results ||= row.best_results
+
+    def scored_results
+      @scored_results ||= row.results.select { |result| result.result&.positive? }
+    end
+  end
+
+  Attempt = Struct.new(:round, :result, :counting, :best)
+
+  Faller = Struct.new(
+    :name, :bib, :country_code, :country_name, :suit, :photo_url, :color, :result, :points,
+    keyword_init: true
+  ) do
+    def self.build(row, color)
+      record = row.best
+      return unless record&.track
+
+      points = PerformanceCompetition::Display::Trajectory.new(record).points
+      return if points.size < 2
+
+      new(
+        name: row.name,
+        bib: row.rank,
+        country_code: row.country_code,
+        country_name: row.country_name,
+        suit: row.suit,
+        photo_url: row.photo_url,
+        color: color,
+        result: record.result.round,
+        points: points
+      )
+    end
+
+    def window_start = points.first[:alt]
+
+    def window_end = points.last[:alt]
+
+    def as_json(*)
+      {
+        name:,
+        color:,
+        result: format('%d', result),
+        resultValue: result.to_f,
+        windowStart: window_start,
+        windowEnd: window_end,
+        points:
+      }
+    end
+  end
+
+  private
+
+  def scoreboard = @scoreboard ||= @event.standings
+
+  def assign_ranks(rows)
+    previous = nil
+
+    rows.each_with_index do |row, index|
+      shares_rank = previous && previous.total_points == row.total_points && row.total_points.positive?
+      row.rank = shares_rank ? previous.rank : index + 1
+      previous = row
+    end
+  end
+end

--- a/app/models/boogie/scoreboard.rb
+++ b/app/models/boogie/scoreboard.rb
@@ -22,7 +22,7 @@ class Boogie::Scoreboard
     @categories ||=
       event
       .categories
-      .includes(competitors: [:event, { profile: :country, suit: :manufacturer }])
+      .includes(competitors: [:event, :competitor_alias, { profile: :country, suit: :manufacturer }])
       .ordered
       .index_with { |category| category_standings(category) }
   end
@@ -40,6 +40,6 @@ class Boogie::Scoreboard
   end
 
   def results
-    @results ||= event.results.includes(:round, :competitor)
+    @results ||= event.results.includes(:round, :competitor, :track)
   end
 end

--- a/app/views/boogies/_actions_bar.html.erb
+++ b/app/views/boogies/_actions_bar.html.erb
@@ -22,23 +22,30 @@
     <% end %>
   <% end %>
 
-  <% if editable %>
-    <div class="actions-bar-right" data-controller="dropdown">
-      <button class="actions-bar-button" popovertarget="boogie-status-menu-<%= event.id %>">
-        <%= t('activerecord.attributes.event.status') + ': ' + t('event_status.' + event.status) %>
-        <%= icon_tag 'angle-down-solid' %>
-      </button>
+  <div class="actions-bar-right">
+    <%= link_to boogie_display_path(event), target: '_blank', rel: 'noopener', class: 'actions-bar-button' do %>
+      <%= icon_tag 'circle-play' %>
+      <%= t('boogies.actions_bar.display') %>
+    <% end %>
 
-      <div id="boogie-status-menu-<%= event.id %>" popover class="sd-dropdown-menu" data-dropdown-target="menu">
-        <% Boogie.statuses.each do |status, _index| %>
-          <%= button_to(t("event_status.#{status}"),
-                      boogie_path(event),
-                      method: :patch,
-                      form: { data: { turbo_stream: true } },
-                      params: { 'boogie[status]' => status },
-                      class: "dropdown-item #{'active' if event.status == status}") %>
-        <% end %>
+    <% if editable %>
+      <div data-controller="dropdown">
+        <button class="actions-bar-button" popovertarget="boogie-status-menu-<%= event.id %>">
+          <%= t('activerecord.attributes.event.status') + ': ' + t('event_status.' + event.status) %>
+          <%= icon_tag 'angle-down-solid' %>
+        </button>
+
+        <div id="boogie-status-menu-<%= event.id %>" popover class="sd-dropdown-menu" data-dropdown-target="menu">
+          <% Boogie.statuses.each do |status, _index| %>
+            <%= button_to(t("event_status.#{status}"),
+                          boogie_path(event),
+                          method: :patch,
+                          form: { data: { turbo_stream: true } },
+                          params: { 'boogie[status]' => status },
+                          class: "dropdown-item #{'active' if event.status == status}") %>
+          <% end %>
+        </div>
       </div>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/boogies/competitors/_form_modal.html.erb
+++ b/app/views/boogies/competitors/_form_modal.html.erb
@@ -29,6 +29,27 @@
       <%= render 'hot_select/local_select', form: f, name: :section_id, options:, class: 'col-8', hide_clear_button: true %>
     </div>
 
+    <div class="form-divider"></div>
+
+    <h3 class="form-section-title">
+      <%= t('competitors.form.show_images') %>
+    </h3>
+
+    <div class="grid">
+      <%= f.label :photo, Boogie::Competitor.human_attribute_name(:photo), class: 'form-label col-4' %>
+      <div class="col-8">
+        <% if @competitor.photo %>
+          <div class="form-static"><%= image_tag @competitor.photo_url(:medium), class: 'competitor-image-preview' %></div>
+        <% end %>
+        <div data-controller="filefield">
+          <%= f.hidden_field :photo, value: @competitor.cached_photo_data %>
+          <%= f.file_field :photo, class: 'form-input',
+                           data: { filefield_target: 'file_field', action: 'change->filefield#change' } %>
+          <div class="file-name" data-filefield-target="text_field"></div>
+        </div>
+      </div>
+    </div>
+
     <div class="form-actions">
       <%= f.submit t('general.save'), class: 'button button--primary' %>
       <button type="button" class="button" data-action="dialog#close"><%= t 'general.cancel' %></button>

--- a/app/views/boogies/displays/_leaderboard.html.erb
+++ b/app/views/boogies/displays/_leaderboard.html.erb
@@ -1,0 +1,59 @@
+<%# locals: (event:, category:, active: false) %>
+
+<div class="display-slide <%= 'is-active' if active %>" data-slideshow-target="slide" data-slideshow-duration="30">
+  <%= render 'statusbar', event: event %>
+
+  <div class="display-content">
+    <div class="display-title-row">
+      <h1 class="display-title"><%= category.name %></h1>
+      <div class="display-title-aside">
+        <span class="display-title-count"><%= t('boogies.display.athletes', count: category.size) %></span>
+      </div>
+    </div>
+
+    <div class="display-lb-head">
+      <span><%= t('boogies.display.rank') %></span>
+      <span><%= t('boogies.display.competitor') %></span>
+      <span class="text-right"><%= t('boogies.display.total') %></span>
+      <span><%= t('boogies.display.results', count: category.counting_results) %></span>
+    </div>
+
+    <div class="display-lb-window">
+      <div class="display-lb-scroller" data-slideshow-scroll>
+        <% category.leaderboard.each do |row| %>
+          <div class="display-lb-row <%= class_names('is-leader' => row.rank == 1, 'is-podium' => row.rank <= 3) %>">
+            <div class="display-rank">
+              <span class="display-rank-number"><%= row.rank %></span>
+            </div>
+
+            <div class="display-competitor">
+              <span class="display-competitor-name"><%= row.name %></span>
+              <div class="display-competitor-meta">
+                <span class="display-country">
+                  <span class="display-country-code"><%= row.country_code %></span>
+                  <span class="display-country-name"><%= row.country_name %></span>
+                </span>
+                <% if row.suit.present? %><span class="display-suit"><%= row.suit %></span><% end %>
+              </div>
+            </div>
+
+            <div class="display-metric">
+              <span class="display-metric-value display-metric-total">
+                <%= row.total_points.positive? ? format('%d', row.total_points) : '—' %>
+              </span>
+            </div>
+
+            <div class="display-lb-tiles">
+              <% row.attempts.each do |attempt| %>
+                <span class="display-lb-tile <%= 'is-best' if attempt.counting %>"><%= format('%d', attempt.result) %></span>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+
+      <div class="display-fade-top"></div>
+      <div class="display-fade-bottom"></div>
+    </div>
+  </div>
+</div>

--- a/app/views/boogies/displays/_participant.html.erb
+++ b/app/views/boogies/displays/_participant.html.erb
@@ -1,0 +1,85 @@
+<%# locals: (event:, category:, row:, field_size:) %>
+
+<div class="display-slide display-participant" data-slideshow-target="slide" data-slideshow-duration="11">
+  <%= render 'statusbar', event: event %>
+
+  <div class="display-participant-photo <%= 'is-empty' unless row.photo_url %>">
+    <% if row.photo_url %><%= image_tag row.photo_url, alt: row.name %><% end %>
+  </div>
+  <div class="display-participant-edge"></div>
+
+  <div class="display-pcontent">
+    <div class="display-phead">
+      <div class="display-pname-block">
+        <h1 class="display-pname"><%= row.name %></h1>
+        <div class="display-pmeta">
+          <span class="display-pcountry">
+            <span class="display-pcountry-code"><%= row.country_code %></span>
+            <span class="display-pcountry-name"><%= row.country_name %></span>
+          </span>
+          <% if row.suit.present? %>
+            <span class="display-psuit">
+              <%= t('boogies.display.flying') %>
+              <strong><%= row.suit %></strong>
+            </span>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+    <div class="display-phero">
+      <div class="display-besttime">
+        <div class="display-besttime-bar"></div>
+        <div class="display-besttime-body">
+          <span class="display-label"><%= t('boogies.display.best_distance') %></span>
+          <div class="display-besttime-value">
+            <span class="num"><%= format('%d', row.best.result) %></span>
+            <span class="unit"><%= t('boogies.display.meters_short') %></span>
+          </div>
+          <div class="display-besttime-sub">
+            <span class="run">
+              <%= t('boogies.display.round', number: row.best_round) %> · <%= t('boogies.display.furthest') %>
+            </span>
+            <span class="divider"></span>
+            <div>
+              <span class="ts-label"><%= t('boogies.display.jumps') %></span>
+              <div class="ts-value"><%= row.jumps %></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="display-rankcard">
+        <span class="display-label"><%= t('boogies.display.rank') %></span>
+        <div class="display-rankcard-value">
+          <span class="num"><%= row.rank %></span>
+          <span class="total">/ <%= field_size %></span>
+        </div>
+        <span class="display-rankcard-gap">
+          <%= t('boogies.display.total') %>: <%= row.total_points.positive? ? format('%d', row.total_points) : '—' %>
+        </span>
+      </div>
+    </div>
+
+    <div class="display-attempts">
+      <div class="display-attempts-title">
+        <span><%= t('boogies.display.rounds') %></span>
+        <span class="rule"></span>
+      </div>
+      <div class="display-attempts-head">
+        <span><%= t('boogies.display.round_short') %></span>
+        <span class="text-right"><%= t('boogies.display.distance') %></span>
+        <span class="text-right"><%= t('boogies.display.vs_best') %></span>
+      </div>
+      <% row.attempts.each do |attempt| %>
+        <div class="display-attempts-row <%= 'is-best' if attempt.counting %>">
+          <span class="run"><%= t('boogies.display.round', number: attempt.round) %></span>
+          <span class="time"><%= format('%d', attempt.result) %> <%= t('boogies.display.meters_short') %></span>
+          <span class="delta">
+            <%= attempt.best ? t('boogies.display.best_short') : format('%d', attempt.result - row.best.result) %>
+          </span>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/boogies/displays/_replay.html.erb
+++ b/app/views/boogies/displays/_replay.html.erb
@@ -1,0 +1,40 @@
+<%# locals: (event:, category:, fallers:) %>
+
+<div class="display-slide display-fall display-replay"
+     data-slideshow-target="slide"
+     data-slideshow-duration="23"
+     data-controller="performance-replay"
+     data-performance-replay-discipline-value="distance"
+     data-performance-replay-window-start-value="<%= event.range_from %>"
+     data-performance-replay-window-end-value="<%= event.range_to %>"
+     data-start-label="<%= t('boogies.display.window_start') %>"
+     data-finish-label="<%= t('boogies.display.window_end') %>">
+  <%= render 'statusbar', event: event %>
+
+  <script type="application/json" data-performance-replay-target="data"><%= raw fallers.to_json %></script>
+
+  <div class="display-replay-body">
+    <%= render 'replay_card', faller: fallers.first, side: 'a' %>
+
+    <div class="display-replay-center">
+      <div class="display-replay-maphead">
+        <span class="display-replay-maptitle">
+          <%= category.name %> · <%= t('boogies.display.best_jumps') %>
+        </span>
+      </div>
+      <div class="display-fall-stage">
+        <svg class="display-fall-svg" data-performance-replay-target="svg"
+             id="boogie-replay-svg-<%= Digest::SHA1.hexdigest([category.name, *fallers.map(&:name)].join('|'))[0, 12] %>"
+             data-turbo-permanent
+             preserveAspectRatio="xMidYMid meet" aria-hidden="true"></svg>
+      </div>
+      <div class="display-replay-countdown" data-performance-replay-target="countdown" hidden>
+        <span class="count" data-performance-replay-target="countText">3</span>
+      </div>
+    </div>
+
+    <% if fallers.second %>
+      <%= render 'replay_card', faller: fallers.second, side: 'b' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/boogies/displays/_replay_card.html.erb
+++ b/app/views/boogies/displays/_replay_card.html.erb
@@ -1,0 +1,65 @@
+<%# locals: (faller:, side:) %>
+
+<div class="display-replay-card display-fall-card is-<%= side %>" style="--side: <%= faller.color %>;" data-performance-replay-target="card">
+  <div class="display-replay-head">
+    <div class="display-replay-id">
+      <h2 class="display-replay-name"><%= faller.name %></h2>
+      <div class="display-replay-meta">
+        <span class="display-pcountry">
+          <span class="display-pcountry-code" style="color: <%= faller.color %>;"><%= faller.country_code %></span>
+          <span class="display-pcountry-name"><%= faller.country_name %></span>
+        </span>
+        <% if faller.suit.present? %><span class="display-psuit"><%= faller.suit %></span><% end %>
+      </div>
+    </div>
+  </div>
+
+  <div class="display-replay-photo <%= 'is-empty' unless faller.photo_url %>">
+    <% if faller.photo_url %><%= image_tag faller.photo_url, alt: faller.name %><% end %>
+  </div>
+
+  <div class="display-replay-stats">
+    <div class="display-replay-stat is-primary">
+      <span class="display-replay-stat-label"><%= t('boogies.display.distance') %></span>
+      <div class="display-replay-stat-value">
+        <span class="num" data-performance-replay-target="result" style="color: <%= faller.color %>;">0</span>
+      </div>
+    </div>
+
+    <div class="display-replay-stat display-replay-speedglide">
+      <div class="display-replay-speedblock">
+        <span class="display-replay-stat-label"><%= t('boogies.display.speed') %></span>
+        <div class="display-replay-speed-row">
+          <%= icon_tag 'angle-right-solid', class: 'display-replay-speed-icon' %>
+          <span class="num" data-performance-replay-target="hspeed">0</span>
+          <span class="unit"><%= t('boogies.display.kmh_short') %></span>
+        </div>
+        <div class="display-replay-speed-row">
+          <%= icon_tag 'angle-down-solid', class: 'display-replay-speed-icon' %>
+          <span class="num" data-performance-replay-target="vspeed">0</span>
+          <span class="unit"><%= t('boogies.display.kmh_short') %></span>
+        </div>
+      </div>
+      <div class="display-replay-glideblock">
+        <span class="display-replay-stat-label"><%= t('boogies.display.glide_ratio') %></span>
+        <span class="display-replay-glide-num" data-performance-replay-target="glide">0.0</span>
+      </div>
+    </div>
+
+    <div class="display-replay-stat">
+      <span class="display-replay-stat-label"><%= t('boogies.display.altitude') %></span>
+      <div class="display-replay-stat-value">
+        <span class="num" data-performance-replay-target="altitude">0</span>
+        <span class="unit"><%= t('boogies.display.meters_short') %></span>
+      </div>
+    </div>
+
+    <div class="display-replay-stat">
+      <span class="display-replay-stat-label"><%= t('boogies.display.to_window_end') %></span>
+      <div class="display-replay-stat-value">
+        <span class="num" data-performance-replay-target="remaining">0</span>
+        <span class="unit"><%= t('boogies.display.meters_short') %></span>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/boogies/displays/_statusbar.html.erb
+++ b/app/views/boogies/displays/_statusbar.html.erb
@@ -1,0 +1,14 @@
+<%# locals: (event:) %>
+
+<div class="display-statusbar">
+  <div class="display-statusbar-left">
+    <span class="display-live-dot"></span>
+    <span class="display-live-label"><%= t('boogies.display.live') %></span>
+    <span class="display-statusbar-divider"></span>
+    <span class="display-statusbar-meta"><%= event.name %></span>
+  </div>
+
+  <div class="display-brand">
+    <span class="display-brand-name">Skyderby</span>
+  </div>
+</div>

--- a/app/views/boogies/displays/show.html.erb
+++ b/app/views/boogies/displays/show.html.erb
@@ -1,0 +1,21 @@
+<% provide :title, @event.name %>
+
+<div class="display-wrap display-boogie"
+     data-controller="slideshow refresh"
+     data-refresh-interval-seconds-value="300">
+  <div class="display-stage">
+    <div class="display-backdrop"></div>
+
+    <% @display.categories.each_with_index do |category, index| %>
+      <%= render 'leaderboard', event: @event, category: category, active: index.zero? %>
+
+      <% category.leaderboard.each do |row| %>
+        <%= render 'participant', event: @event, category: category, row: row, field_size: category.size %>
+      <% end %>
+
+      <% category.fall_pairs.each do |pair| %>
+        <%= render 'replay', event: @event, category: category, fallers: pair %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/boogies.de.yml
+++ b/config/locales/boogies.de.yml
@@ -1,0 +1,34 @@
+de:
+  boogies:
+    actions_bar:
+      display: 'Diashow'
+    display:
+      live: 'Live'
+      athletes:
+        one: '%{count} Athlet'
+        other: '%{count} Athleten'
+      results:
+        one: 'Bestes Ergebnis'
+        other: 'Beste %{count} Ergebnisse'
+      rank: 'Platz'
+      competitor: 'Teilnehmer'
+      total: 'Gesamt'
+      distance: 'Distanz'
+      best_distance: 'Beste Distanz'
+      best_jumps: 'Beste Sprünge'
+      furthest: 'am weitesten'
+      flying: 'Fliegt'
+      jumps: 'Sprünge'
+      speed: 'Geschwindigkeit'
+      glide_ratio: 'Gleitzahl'
+      altitude: 'Höhe'
+      kmh_short: 'KM/H'
+      meters_short: 'M'
+      rounds: 'Runden'
+      round_short: 'Runde'
+      round: 'Runde %{number}'
+      best_short: 'beste'
+      vs_best: 'zur besten'
+      to_window_end: 'Bis Fensterende'
+      window_start: 'Fensterbeginn'
+      window_end: 'Fensterende'

--- a/config/locales/boogies.en.yml
+++ b/config/locales/boogies.en.yml
@@ -1,0 +1,34 @@
+en:
+  boogies:
+    actions_bar:
+      display: 'Slide Show'
+    display:
+      live: 'Live'
+      athletes:
+        one: '%{count} Athlete'
+        other: '%{count} Athletes'
+      results:
+        one: 'Best result'
+        other: 'Best %{count} results'
+      rank: 'Rank'
+      competitor: 'Competitor'
+      total: 'Total'
+      distance: 'Distance'
+      best_distance: 'Best distance'
+      best_jumps: 'Best jumps'
+      furthest: 'furthest'
+      flying: 'Flying'
+      jumps: 'Jumps'
+      speed: 'Speed'
+      glide_ratio: 'Glide ratio'
+      altitude: 'Altitude'
+      kmh_short: 'KM/H'
+      meters_short: 'M'
+      rounds: 'Rounds'
+      round_short: 'Round'
+      round: 'Round %{number}'
+      best_short: 'best'
+      vs_best: 'vs best'
+      to_window_end: 'To window end'
+      window_start: 'Window start'
+      window_end: 'Window end'

--- a/config/locales/boogies.es.yml
+++ b/config/locales/boogies.es.yml
@@ -1,0 +1,34 @@
+es:
+  boogies:
+    actions_bar:
+      display: 'Presentación'
+    display:
+      live: 'En directo'
+      athletes:
+        one: '%{count} atleta'
+        other: '%{count} atletas'
+      results:
+        one: 'Mejor resultado'
+        other: 'Mejores %{count} resultados'
+      rank: 'Puesto'
+      competitor: 'Competidor'
+      total: 'Total'
+      distance: 'Distancia'
+      best_distance: 'Mejor distancia'
+      best_jumps: 'Mejores saltos'
+      furthest: 'más lejos'
+      flying: 'Vuela'
+      jumps: 'Saltos'
+      speed: 'Velocidad'
+      glide_ratio: 'Planeo'
+      altitude: 'Altitud'
+      kmh_short: 'KM/H'
+      meters_short: 'M'
+      rounds: 'Rondas'
+      round_short: 'Ronda'
+      round: 'Ronda %{number}'
+      best_short: 'mejor'
+      vs_best: 'vs mejor'
+      to_window_end: 'Hasta fin de ventana'
+      window_start: 'Inicio de ventana'
+      window_end: 'Fin de ventana'

--- a/config/locales/boogies.fr.yml
+++ b/config/locales/boogies.fr.yml
@@ -1,0 +1,34 @@
+fr:
+  boogies:
+    actions_bar:
+      display: 'Diaporama'
+    display:
+      live: 'En direct'
+      athletes:
+        one: '%{count} athlète'
+        other: '%{count} athlètes'
+      results:
+        one: 'Meilleur résultat'
+        other: '%{count} meilleurs résultats'
+      rank: 'Rang'
+      competitor: 'Compétiteur'
+      total: 'Total'
+      distance: 'Distance'
+      best_distance: 'Meilleure distance'
+      best_jumps: 'Meilleurs sauts'
+      furthest: 'le plus loin'
+      flying: 'Vole en'
+      jumps: 'Sauts'
+      speed: 'Vitesse'
+      glide_ratio: 'Finesse'
+      altitude: 'Altitude'
+      kmh_short: 'KM/H'
+      meters_short: 'M'
+      rounds: 'Manches'
+      round_short: 'Manche'
+      round: 'Manche %{number}'
+      best_short: 'meilleur'
+      vs_best: 'vs meilleur'
+      to_window_end: 'Jusqu''à la fin de fenêtre'
+      window_start: 'Début de fenêtre'
+      window_end: 'Fin de fenêtre'

--- a/config/locales/boogies.it.yml
+++ b/config/locales/boogies.it.yml
@@ -1,0 +1,34 @@
+it:
+  boogies:
+    actions_bar:
+      display: 'Presentazione'
+    display:
+      live: 'In diretta'
+      athletes:
+        one: '%{count} atleta'
+        other: '%{count} atleti'
+      results:
+        one: 'Miglior risultato'
+        other: 'Migliori %{count} risultati'
+      rank: 'Posizione'
+      competitor: 'Concorrente'
+      total: 'Totale'
+      distance: 'Distanza'
+      best_distance: 'Miglior distanza'
+      best_jumps: 'Salti migliori'
+      furthest: 'più lontano'
+      flying: 'Vola con'
+      jumps: 'Salti'
+      speed: 'Velocità'
+      glide_ratio: 'Efficienza'
+      altitude: 'Quota'
+      kmh_short: 'KM/H'
+      meters_short: 'M'
+      rounds: 'Round'
+      round_short: 'Round'
+      round: 'Round %{number}'
+      best_short: 'migliore'
+      vs_best: 'vs migliore'
+      to_window_end: 'Alla fine finestra'
+      window_start: 'Inizio finestra'
+      window_end: 'Fine finestra'

--- a/config/locales/boogies.ru.yml
+++ b/config/locales/boogies.ru.yml
@@ -1,0 +1,38 @@
+ru:
+  boogies:
+    actions_bar:
+      display: 'Слайд-шоу'
+    display:
+      live: 'В эфире'
+      athletes:
+        one: '%{count} спортсмен'
+        few: '%{count} спортсмена'
+        many: '%{count} спортсменов'
+        other: '%{count} спортсменов'
+      results:
+        one: 'Лучший результат'
+        few: '%{count} лучших результата'
+        many: '%{count} лучших результатов'
+        other: '%{count} лучших результатов'
+      rank: 'Место'
+      competitor: 'Участник'
+      total: 'Итого'
+      distance: 'Дальность'
+      best_distance: 'Лучшая дальность'
+      best_jumps: 'Лучшие прыжки'
+      furthest: 'дальше всех'
+      flying: 'Летит на'
+      jumps: 'Прыжки'
+      speed: 'Скорость'
+      glide_ratio: 'Качество'
+      altitude: 'Высота'
+      kmh_short: 'КМ/Ч'
+      meters_short: 'М'
+      rounds: 'Раунды'
+      round_short: 'Раунд'
+      round: 'Раунд %{number}'
+      best_short: 'лучший'
+      vs_best: 'к лучшему'
+      to_window_end: 'До конца окна'
+      window_start: 'Начало окна'
+      window_end: 'Конец окна'

--- a/config/locales/models/boogie_competitors.de.yml
+++ b/config/locales/models/boogie_competitors.de.yml
@@ -1,0 +1,5 @@
+de:
+  activerecord:
+    attributes:
+      boogie/competitor:
+        photo: Foto

--- a/config/locales/models/boogie_competitors.en.yml
+++ b/config/locales/models/boogie_competitors.en.yml
@@ -1,0 +1,5 @@
+en:
+  activerecord:
+    attributes:
+      boogie/competitor:
+        photo: Photo

--- a/config/locales/models/boogie_competitors.es.yml
+++ b/config/locales/models/boogie_competitors.es.yml
@@ -1,0 +1,5 @@
+es:
+  activerecord:
+    attributes:
+      boogie/competitor:
+        photo: Foto

--- a/config/locales/models/boogie_competitors.fr.yml
+++ b/config/locales/models/boogie_competitors.fr.yml
@@ -1,0 +1,5 @@
+fr:
+  activerecord:
+    attributes:
+      boogie/competitor:
+        photo: Photo

--- a/config/locales/models/boogie_competitors.it.yml
+++ b/config/locales/models/boogie_competitors.it.yml
@@ -1,0 +1,5 @@
+it:
+  activerecord:
+    attributes:
+      boogie/competitor:
+        photo: Foto

--- a/config/locales/models/boogie_competitors.ru.yml
+++ b/config/locales/models/boogie_competitors.ru.yml
@@ -1,0 +1,5 @@
+ru:
+  activerecord:
+    attributes:
+      boogie/competitor:
+        photo: Фото

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -222,6 +222,7 @@ Skyderby::Application.routes.draw do
       end
 
       resource :deletion, only: %i[new create]
+      resource :display, controller: 'displays', only: :show
     end
   end
 

--- a/test/controllers/boogies/displays_controller_test.rb
+++ b/test/controllers/boogies/displays_controller_test.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+
+module Boogies
+  class DisplaysControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      @event = Boogie.find(events(:boogie).id)
+    end
+
+    test 'display page is accessible without authentication' do
+      get boogie_display_path(@event)
+
+      assert_response :success
+      assert_select '.display-stage'
+      assert_select '.display-slide'
+    end
+
+    test 'display page of a draft event is not accessible without authentication' do
+      @event.update!(status: :draft)
+
+      get boogie_display_path(@event)
+
+      assert_response :forbidden
+    end
+
+    test 'display page allows being embedded in an iframe' do
+      get boogie_display_path(@event)
+
+      assert_equal 'ALLOWALL', response.headers['X-FRAME-OPTIONS']
+    end
+
+    test 'leaderboard highlights the results counting towards the total' do
+      get boogie_display_path(@event)
+
+      assert_select '.display-lb-row', 3
+      assert_select '.display-lb-row:first-child .display-lb-tile.is-best', 2
+    end
+
+    test 'leaderboard ranks only the competitors it shows' do
+      get boogie_display_path(@event)
+
+      ranks = css_select('.display-lb-row .display-rank-number').map { |node| node.text.to_i }
+
+      assert_equal [1, 2, 3], ranks
+      assert_select '.display-rankcard-value .total', text: "/ #{ranks.size}", count: ranks.size
+    end
+
+    test 'actions bar links to the display page' do
+      sign_in @event.responsible
+
+      get boogie_path(@event)
+
+      assert_response :success
+      assert_select 'a[href=?][target=_blank]', boogie_display_path(@event)
+    end
+  end
+end

--- a/test/fixtures/event/competitors.yml
+++ b/test/fixtures/event/competitors.yml
@@ -15,3 +15,27 @@ alex:
   suit: nala
   category: advanced
   profile: alex
+
+boogie_john:
+  event: boogie
+  suit: apache
+  category: boogie_open
+  profile: john
+
+boogie_travis:
+  event: boogie
+  suit: apache
+  category: boogie_open
+  profile: travis
+
+boogie_alex:
+  event: boogie
+  suit: apache
+  category: boogie_open
+  profile: alex
+
+boogie_organizer:
+  event: boogie
+  suit: apache
+  category: boogie_open
+  profile: event_responsible

--- a/test/fixtures/event/results.yml
+++ b/test/fixtures/event/results.yml
@@ -37,3 +37,43 @@ travis_speed_1:
   result_net: 265
   uploaded_by: event_responsible
   created_at: 2018-01-01 12:05:00
+
+boogie_john_1:
+  competitor: boogie_john
+  round: boogie_distance_1
+  result: 3000
+  created_at: 2018-01-01 12:00:00
+  track: boogie_track_1
+  uploaded_by: event_responsible
+
+boogie_john_2:
+  competitor: boogie_john
+  round: boogie_distance_2
+  result: 3200
+  created_at: 2018-01-01 12:01:00
+  track: boogie_track_2
+  uploaded_by: event_responsible
+
+boogie_travis_1:
+  competitor: boogie_travis
+  round: boogie_distance_1
+  result: 2500
+  created_at: 2018-01-01 12:02:00
+  track: boogie_track_3
+  uploaded_by: event_responsible
+
+boogie_travis_2:
+  competitor: boogie_travis
+  round: boogie_distance_2
+  result: 2600
+  created_at: 2018-01-01 12:03:00
+  track: boogie_track_4
+  uploaded_by: event_responsible
+
+boogie_organizer_1:
+  competitor: boogie_organizer
+  round: boogie_distance_1
+  result: 1500
+  created_at: 2018-01-01 12:04:00
+  track: boogie_track_5
+  uploaded_by: event_responsible

--- a/test/fixtures/event/rounds.yml
+++ b/test/fixtures/event/rounds.yml
@@ -12,3 +12,15 @@ speed_1:
   discipline: speed
   number: 1
   completed_at: 2020-01-01 00:00:00
+
+boogie_distance_1:
+  event: boogie
+  discipline: distance
+  number: 1
+  completed_at: 2020-01-01 00:00:00
+
+boogie_distance_2:
+  event: boogie
+  discipline: distance
+  number: 2
+  completed_at: 2020-01-01 00:00:00

--- a/test/fixtures/event/sections.yml
+++ b/test/fixtures/event/sections.yml
@@ -10,3 +10,8 @@ intermediate:
   event: nationals
   order: 2
   name: Intermediate
+
+boogie_open:
+  event: boogie
+  order: 1
+  name: Boogie Open

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -8,3 +8,15 @@ nationals:
   responsible: event_responsible
   status: published
   place: ravenna
+
+boogie:
+  name: Hungary Boogie
+  rules: 2
+  range_from: 3000
+  range_to: 2000
+  wind_cancellation: false
+  number_of_results_for_total: 2
+  starts_at: 2015-03-01
+  responsible: event_responsible
+  status: published
+  place: ravenna

--- a/test/fixtures/tracks.yml
+++ b/test/fixtures/tracks.yml
@@ -13,3 +13,23 @@ track_with_video:
 
 speed_skydiving_track:
   <<: *default
+
+boogie_track_1: &boogie_track
+  <<: *default
+  pilot: john
+  kind: skydive
+
+boogie_track_2:
+  <<: *boogie_track
+
+boogie_track_3:
+  <<: *boogie_track
+  pilot: travis
+
+boogie_track_4:
+  <<: *boogie_track
+  pilot: travis
+
+boogie_track_5:
+  <<: *boogie_track
+  pilot: event_responsible


### PR DESCRIPTION
Hungary Boogie events now have the same full-screen venue display that tournament qualification, performance and speed competitions already have, at `/events/boogies/:id/display`, reachable from a **Slide Show** button in the boogie actions bar.

## What changed

Slides are grouped **per category**, since that is how a boogie is scored — leaderboard, then one card per competitor, then side-view replays:

- **Leaderboard** — follows the speed skydiving layout: rank, competitor, total, and every result as a tile, with the counting results (`number_of_results_for_total`) highlighted.
- **Participant** — best distance, rank card with total, and every round with a `vs best` delta.
- **Replay** — rounds are distance-only in practice, so this reuses the performance competition's distance trajectory (`PerformanceCompetition::Display::Trajectory`) and its `performance-replay` Stimulus controller, rather than the tournament's head-to-head race, which needs a finish line a boogie does not have. Categories with a single competitor still get a solo slide.

Everything is driven by the existing `slideshow` / `refresh` controllers, so the page cycles and morph-refreshes every 5 minutes at a slide boundary, exactly like the other displays.

Supporting changes:

- `Boogie::Display` — a `SimpleDelegator` exposing per-category `Category` / `LeaderRow` / `Faller`, with fallers built from each competitor's **best** jump (top 8 per category).
- Competitor photos mounted on `Boogie::Competitor` plus a form field. `event_competitors` already had the `photo_data` column, so **no migration**.
- Eager loading for `competitor_alias` and `track` in `Boogie::Scoreboard`, fixing N+1s Bullet flagged on both the display and the existing scoreboard page.
- Locales for all six supported languages.
- `.gitignore` now covers rotated logs (`/log/*.log*`), which otherwise show up untracked after a test run.

## Notes for the reviewer

**Ranks are recomputed over the competitors actually shown.** The standings rank the whole field, and competitors with no jumps yet sort interleaved with partially scored ones (both have `total_points == 0`), so reusing that rank left gaps — boogie 12 / "Naked tracking" rendered 12 rows with ranks `[1..11, 18]`, printing "Rank 18 / 12" on a participant card. There is a regression test for this, and I confirmed it fails without the fix.

**Access control matches the boogie's own `viewable?` rule**, not the other display controllers. `PerformanceCompetitions`, `SpeedSkydivingCompetitions` and `Tournaments::Qualifications` displays all skip the guard, so a draft event's standings are publicly readable through them. This one runs `authorize_event_access!`, so a draft boogie returns 403 to an anonymous visitor just like its `show` page does. Worth deciding whether the other three should be brought in line separately.

**One judgment call:** competitors with *any* scored jump are included, not only those who have completed `number_of_results_for_total` rounds — otherwise the screen is empty for most of the boogie. Their total shows `—` until it is positive.

## Testing

- New `Boogies::DisplaysControllerTest` — 6 tests covering access, the draft 403, iframe embedding, counting-result highlighting, and rank contiguity.
- Full suite: 661 runs, 1360 assertions, 0 failures. Rubocop clean.
- Verified in the browser against `X. WINGSUIT BOOGIE HUNGARY` (5 categories, 121 competitors, 132 slides): leaderboard, participant and replay slides all render, ~850ms server-side. Replay playback itself is the controller performance competitions already use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)