### PR TITLE
Add tests for scoreboard visibility and fix surprise event ID

### DIFF
--- a/app/views/boogies/_scoreboard.html.erb
+++ b/app/views/boogies/_scoreboard.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (event:, editable:) %>
 
 <% if event.surprise? && !editable %>
-  <h1 class="text-muted text-center" id="<%= id %>">🙅 Let it be a Surprise</h1>
+  <h1 class="text-muted text-center" id="scoreboard">🙅 Let it be a Surprise</h1>
 <% else %>
   <%= render 'boogies/scoreboard_table_by_category',
              event:, scoreboard: event.standings, editable:, id: 'scoreboard' %>

--- a/test/controllers/boogies_controller_test.rb
+++ b/test/controllers/boogies_controller_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class BoogiesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = Boogie.find(events(:boogie).id)
+  end
+
+  test 'shows the scoreboard' do
+    get boogie_path(@event)
+
+    assert_response :success
+    assert_select '#scoreboard.scoreboard-container'
+  end
+
+  test 'hides the scoreboard of a surprise event from visitors' do
+    @event.update!(status: :surprise)
+
+    get boogie_path(@event)
+
+    assert_response :success
+    assert_select '#scoreboard', text: /Surprise/
+    assert_select '.scoreboard-container', false
+  end
+
+  test 'shows the scoreboard of a surprise event to the responsible' do
+    @event.update!(status: :surprise)
+    sign_in @event.responsible
+
+    get boogie_path(@event)
+
+    assert_response :success
+    assert_select '#scoreboard.scoreboard-container'
+  end
+end


### PR DESCRIPTION
## Summary
Add integration tests for the boogies controller to verify scoreboard visibility behavior, and fix a bug where the surprise event message was using an incorrect HTML ID.

## Changes
- **New test file**: `test/controllers/boogies_controller_test.rb`
  - Test that scoreboard displays normally for regular events
  - Test that scoreboard is hidden for surprise events (shows "Let it be a Surprise" message instead)
  - Test that scoreboard is visible to the event responsible person even for surprise events

- **Bug fix**: `app/views/boogies/_scoreboard.html.erb`
  - Changed the surprise event message element ID from `<%= id %>` to `scoreboard` to match the ID used in the scoreboard table render, ensuring consistent element identification for testing and styling

## Implementation Details
The tests verify that the surprise event feature properly restricts scoreboard visibility to unauthorized visitors while allowing the responsible person full access. The ID fix ensures the surprise message element can be reliably targeted by CSS selectors and JavaScript.

https://claude.ai/code/session_01QCN5Fg1wRdpY2Q5Q9AUAwG